### PR TITLE
Feature/44 graphql integration tests

### DIFF
--- a/modules/vf-graphql-holochain/mutations/commitment.ts
+++ b/modules/vf-graphql-holochain/mutations/commitment.ts
@@ -13,9 +13,9 @@ import {
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
-const createHandler = zomeFunction('a1_planning', 'commitment', 'create_commitment')
-const updateHandler = zomeFunction('a1_planning', 'commitment', 'update_commitment')
-const deleteHandler = zomeFunction('a1_planning', 'commitment', 'delete_commitment')
+const createHandler = zomeFunction('planning', 'commitment', 'create_commitment')
+const updateHandler = zomeFunction('planning', 'commitment', 'update_commitment')
+const deleteHandler = zomeFunction('planning', 'commitment', 'delete_commitment')
 
 // CREATE
 interface CreateArgs {

--- a/modules/vf-graphql-holochain/mutations/economicEvent.ts
+++ b/modules/vf-graphql-holochain/mutations/economicEvent.ts
@@ -14,9 +14,9 @@ import {
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
-const createEvent = zomeFunction('a1_observation', 'economic_event', 'create_event')
-const updateEvent = zomeFunction('a1_observation', 'economic_event', 'update_event')
-const deleteEvent = zomeFunction('a1_observation', 'economic_event', 'delete_event')
+const createEvent = zomeFunction('observation', 'economic_event', 'create_event')
+const updateEvent = zomeFunction('observation', 'economic_event', 'update_event')
+const deleteEvent = zomeFunction('observation', 'economic_event', 'delete_event')
 
 // CREATE
 interface CreateArgs {

--- a/modules/vf-graphql-holochain/mutations/fulfillment.ts
+++ b/modules/vf-graphql-holochain/mutations/fulfillment.ts
@@ -13,9 +13,9 @@ import {
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
-const createHandler = zomeFunction('a1_planning', 'fulfillment', 'create_fulfillment')
-const updateHandler = zomeFunction('a1_planning', 'fulfillment', 'update_fulfillment')
-const deleteHandler = zomeFunction('a1_planning', 'fulfillment', 'delete_fulfillment')
+const createHandler = zomeFunction('planning', 'fulfillment', 'create_fulfillment')
+const updateHandler = zomeFunction('planning', 'fulfillment', 'update_fulfillment')
+const deleteHandler = zomeFunction('planning', 'fulfillment', 'delete_fulfillment')
 
 // CREATE
 interface CreateArgs {

--- a/modules/vf-graphql-holochain/mutations/intent.ts
+++ b/modules/vf-graphql-holochain/mutations/intent.ts
@@ -13,9 +13,9 @@ import {
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
-const createHandler = zomeFunction('a1_planning', 'intent', 'create_intent')
-const updateHandler = zomeFunction('a1_planning', 'intent', 'update_intent')
-const deleteHandler = zomeFunction('a1_planning', 'intent', 'delete_intent')
+const createHandler = zomeFunction('planning', 'intent', 'create_intent')
+const updateHandler = zomeFunction('planning', 'intent', 'update_intent')
+const deleteHandler = zomeFunction('planning', 'intent', 'delete_intent')
 
 // CREATE
 interface CreateArgs {

--- a/modules/vf-graphql-holochain/mutations/process.ts
+++ b/modules/vf-graphql-holochain/mutations/process.ts
@@ -1,0 +1,45 @@
+/**
+ * Mutations for manipulating processes
+ *
+ * @package: HoloREA
+ * @since:   2019-09-12
+ */
+
+import { zomeFunction } from '../connection'
+import {
+  ProcessCreateParams,
+  ProcessUpdateParams,
+  ProcessResponse,
+} from '@valueflows/vf-graphql'
+
+// :TODO: how to inject DNA identifier?
+const createHandler = zomeFunction('observation', 'process', 'create_process')
+const updateHandler = zomeFunction('observation', 'process', 'update_process')
+const deleteHandler = zomeFunction('observation', 'process', 'delete_process')
+
+// CREATE
+interface CreateArgs {
+  process: ProcessCreateParams,
+}
+type createHandler = (root: any, args: CreateArgs) => Promise<ProcessResponse>
+
+export const createProcess: createHandler = async (root, args) => {
+  return (await createHandler)(args)
+}
+
+// UPDATE
+interface UpdateArgs {
+  process: ProcessUpdateParams,
+}
+type updateHandler = (root: any, args: UpdateArgs) => Promise<ProcessResponse>
+
+export const updateProcess: updateHandler = async (root, args) => {
+  return (await updateHandler)(args)
+}
+
+// DELETE
+type deleteHandler = (root: any, args: { id: string }) => Promise<boolean>
+
+export const deleteProcess: deleteHandler = async (root, args) => {
+  return (await deleteHandler)({ address: args.id })
+}

--- a/modules/vf-graphql-holochain/mutations/satisfaction.ts
+++ b/modules/vf-graphql-holochain/mutations/satisfaction.ts
@@ -13,9 +13,9 @@ import {
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
-const createHandler = zomeFunction('a1_planning', 'satisfaction', 'create_satisfaction')
-const updateHandler = zomeFunction('a1_planning', 'satisfaction', 'update_satisfaction')
-const deleteHandler = zomeFunction('a1_planning', 'satisfaction', 'delete_satisfaction')
+const createHandler = zomeFunction('planning', 'satisfaction', 'create_satisfaction')
+const updateHandler = zomeFunction('planning', 'satisfaction', 'update_satisfaction')
+const deleteHandler = zomeFunction('planning', 'satisfaction', 'delete_satisfaction')
 
 // CREATE
 interface CreateArgs {

--- a/modules/vf-graphql-holochain/package.json
+++ b/modules/vf-graphql-holochain/package.json
@@ -37,7 +37,7 @@
     "@valueflows/vf-graphql": "0.0.1",
     "dataloader": "^1.4.0",
     "fecha": "^3.0.3",
-    "graphql": "^14.3.0",
+    "graphql": "14.5.8",
     "graphql-tools": "^4.0.4"
   },
   "devDependencies": {

--- a/modules/vf-graphql-holochain/queries/commitment.ts
+++ b/modules/vf-graphql-holochain/queries/commitment.ts
@@ -12,7 +12,7 @@ import {
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
-const readCommitment = zomeFunction('a1_planning', 'commitment', 'get_commitment')
+const readCommitment = zomeFunction('planning', 'commitment', 'get_commitment')
 
 // Read a single commitment by ID
 export const commitment = async (root, args): Promise<Commitment> => {

--- a/modules/vf-graphql-holochain/queries/economicEvent.ts
+++ b/modules/vf-graphql-holochain/queries/economicEvent.ts
@@ -12,7 +12,7 @@ import {
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
-const readEvent = zomeFunction('a1_observation', 'economic_event', 'get_event')
+const readEvent = zomeFunction('observation', 'economic_event', 'get_event')
 
 // Read a single event by ID
 export const economicEvent = async (root, args): Promise<EconomicEvent> => {

--- a/modules/vf-graphql-holochain/queries/fulfillment.ts
+++ b/modules/vf-graphql-holochain/queries/fulfillment.ts
@@ -12,7 +12,7 @@ import {
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
-const readFulfullment = zomeFunction('a1_planning', 'fulfillment', 'get_fulfillment')
+const readFulfullment = zomeFunction('planning', 'fulfillment', 'get_fulfillment')
 
 // Read a single commitment by ID
 export const fulfillment = async (root, args): Promise<Fulfillment> => {

--- a/modules/vf-graphql-holochain/queries/intent.ts
+++ b/modules/vf-graphql-holochain/queries/intent.ts
@@ -12,7 +12,7 @@ import {
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
-const readRecord = zomeFunction('a1_planning', 'intent', 'get_intent')
+const readRecord = zomeFunction('planning', 'intent', 'get_intent')
 
 // Read a single commitment by ID
 export const intent = async (root, args): Promise<Intent> => {

--- a/modules/vf-graphql-holochain/queries/process.ts
+++ b/modules/vf-graphql-holochain/queries/process.ts
@@ -1,0 +1,20 @@
+/**
+ * Top-level queries relating to Processes
+ *
+ * @package: HoloREA
+ * @since:   2019-09-12
+ */
+
+import { zomeFunction } from '../connection'
+
+import {
+  Process,
+} from '@valueflows/vf-graphql'
+
+// :TODO: how to inject DNA identifier?
+const readProcess = zomeFunction('observation', 'process', 'get_process')
+
+// Read a single record by ID
+export const process = async (root, args): Promise<Process> => {
+  return (await (await readProcess)({ address: args.id })).process
+}

--- a/modules/vf-graphql-holochain/queries/satisfaction.ts
+++ b/modules/vf-graphql-holochain/queries/satisfaction.ts
@@ -12,7 +12,7 @@ import {
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
-const readRecord = zomeFunction('a1_planning', 'satisfaction', 'get_satisfaction')
+const readRecord = zomeFunction('planning', 'satisfaction', 'get_satisfaction')
 
 // Read a single commitment by ID
 export const satisfaction = async (root, args): Promise<Satisfaction> => {

--- a/modules/vf-graphql-holochain/resolvers/commitment.ts
+++ b/modules/vf-graphql-holochain/resolvers/commitment.ts
@@ -14,8 +14,8 @@ import {
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
-const readFulfillments = zomeFunction('a1_planning', 'fulfillment', 'query_fulfillments')
-const readSatisfactions = zomeFunction('a1_planning', 'satisfaction', 'query_satisfactions')
+const readFulfillments = zomeFunction('planning', 'fulfillment', 'query_fulfillments')
+const readSatisfactions = zomeFunction('planning', 'satisfaction', 'query_satisfactions')
 
 export const fulfilledBy = async (record: Commitment): Promise<[Fulfillment]> => {
   return (await (await readFulfillments)({ commitment: record.id })).map(({ fulfillment }) => fulfillment)

--- a/modules/vf-graphql-holochain/resolvers/economicEvent.ts
+++ b/modules/vf-graphql-holochain/resolvers/economicEvent.ts
@@ -14,8 +14,8 @@ import {
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
-const readFulfillments = zomeFunction('a1_observation', 'fulfillment', 'query_fulfillments')
-const readSatisfactions = zomeFunction('a1_planning', 'satisfaction', 'query_satisfactions')
+const readFulfillments = zomeFunction('observation', 'fulfillment', 'query_fulfillments')
+const readSatisfactions = zomeFunction('planning', 'satisfaction', 'query_satisfactions')
 
 export const fulfills = async (record: EconomicEvent): Promise<[Fulfillment]> => {
   return (await (await readFulfillments)({ economic_event: record.id })).map(({ fulfillment }) => fulfillment)

--- a/modules/vf-graphql-holochain/resolvers/fulfillment.ts
+++ b/modules/vf-graphql-holochain/resolvers/fulfillment.ts
@@ -14,8 +14,8 @@ import {
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
-const readEvents = zomeFunction('a1_observation', 'economic_event', 'query_events')
-const readCommitments = zomeFunction('a1_planning', 'commitment', 'query_commitments')
+const readEvents = zomeFunction('observation', 'economic_event', 'query_events')
+const readCommitments = zomeFunction('planning', 'commitment', 'query_commitments')
 
 export const fulfilledBy = async (record: Fulfillment): Promise<EconomicEvent> => {
   return (await (await readEvents)({ fulfills: record.id })).map(({ economicEvent }) => economicEvent)[0]

--- a/modules/vf-graphql-holochain/resolvers/intent.ts
+++ b/modules/vf-graphql-holochain/resolvers/intent.ts
@@ -13,7 +13,7 @@ import {
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
-const readSatisfactions = zomeFunction('a1_planning', 'satisfaction', 'query_satisfactions')
+const readSatisfactions = zomeFunction('planning', 'satisfaction', 'query_satisfactions')
 
 export const satisfiedBy = async (record: Intent): Promise<[Satisfaction]> => {
   return (await (await readSatisfactions)({ satisfies: record.id })).map(({ satisfaction }) => satisfaction)

--- a/modules/vf-graphql-holochain/resolvers/process.ts
+++ b/modules/vf-graphql-holochain/resolvers/process.ts
@@ -1,0 +1,44 @@
+/**
+ * Resolvers for Process fields
+ *
+ * @package: HoloREA
+ * @since:   2019-09-12
+ */
+
+import { zomeFunction } from '../connection'
+
+import {
+  Process,
+  EconomicEvent,
+  Commitment,
+  Intent,
+} from '@valueflows/vf-graphql'
+
+// :TODO: how to inject DNA identifier?
+const readEvents = zomeFunction('observation', 'economic_event', 'query_events')
+const readCommitments = zomeFunction('planning', 'commitment', 'query_commitments')
+const readIntents = zomeFunction('planning', 'intent', 'query_intents')
+
+export const inputs = async (record: Process): Promise<[EconomicEvent]> => {
+  return (await (await readEvents)({ params: { inputOf: record.id } })).map(({ economicEvent }) => economicEvent)
+}
+
+export const outputs = async (record: Process): Promise<[EconomicEvent]> => {
+  return (await (await readEvents)({ params: { outputOf: record.id } })).map(({ economicEvent }) => economicEvent)
+}
+
+export const committedInputs = async (record: Process): Promise<[Commitment]> => {
+  return (await (await readCommitments)({ params: { inputOf: record.id } })).map(({ commitment }) => commitment)
+}
+
+export const committedOutputs = async (record: Process): Promise<[Commitment]> => {
+  return (await (await readCommitments)({ params: { outputOf: record.id } })).map(({ commitment }) => commitment)
+}
+
+export const intendedInputs = async (record: Process): Promise<[Intent]> => {
+  return (await (await readIntents)({ params: { inputOf: record.id } })).map(({ intent }) => intent)
+}
+
+export const intendedOutputs = async (record: Process): Promise<[Intent]> => {
+  return (await (await readIntents)({ params: { outputOf: record.id } })).map(({ intent }) => intent)
+}

--- a/modules/vf-graphql-holochain/resolvers/satisfaction.ts
+++ b/modules/vf-graphql-holochain/resolvers/satisfaction.ts
@@ -14,9 +14,9 @@ import {
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
-const readEvents = zomeFunction('a1_observation', 'economic_event', 'query_events')
-const readCommitments = zomeFunction('a1_planning', 'commitment', 'query_commitments')
-const readIntents = zomeFunction('a1_planning', 'intent', 'query_intents')
+const readEvents = zomeFunction('observation', 'economic_event', 'query_events')
+const readCommitments = zomeFunction('planning', 'commitment', 'query_commitments')
+const readIntents = zomeFunction('planning', 'intent', 'query_intents')
 
 async function extractRecordsOrFail(query, subfieldId: string): Promise<any> {
   const val = await query

--- a/test/core-architecture/test_default_values.js
+++ b/test/core-architecture/test_default_values.js
@@ -1,25 +1,28 @@
 const {
   getDNA,
-  buildOrchestrator,
+  buildConfig,
+  runner,
 } = require('../init')
 
-const runner = buildOrchestrator({
+const config = buildConfig({
   planning: getDNA('planning'),
 })
 
-runner.registerScenario('fields with default values set are stored on creation', async (s, t, { planning }) => {
+runner.registerScenario('fields with default values set are stored on creation', async (s, t) => {
+  const { planning } = await s.players({ planning: config }, true)
+
   const commitment = {
     note: 'test event',
   }
 
-  const createResponse = await planning.call('commitment', 'create_commitment', { commitment })
+  const createResponse = await planning.call('planning', 'commitment', 'create_commitment', { commitment })
 
   t.ok(createResponse.Ok.commitment && createResponse.Ok.commitment.id, 'record created successfully')
   t.equal(createResponse.Ok.commitment.finished, false, 'default value assigned on creation')
 
-  await s.consistent()
+  await s.consistency()
 
-  const readResponse = await planning.call('commitment', 'get_commitment', { address: createResponse.Ok.commitment.id })
+  const readResponse = await planning.call('planning', 'commitment', 'get_commitment', { address: createResponse.Ok.commitment.id })
 
   t.equal(readResponse.Ok.commitment.finished, false, 'default value present upon reading')
 })

--- a/test/core-architecture/test_record_delete.js
+++ b/test/core-architecture/test_record_delete.js
@@ -1,33 +1,36 @@
 const {
   getDNA,
-  buildOrchestrator,
+  buildConfig,
+  runner,
 } = require('../init')
 
-const runner = buildOrchestrator({
+const config = buildConfig({
   planning: getDNA('planning'),
 })
 
-runner.registerScenario('record deletion API', async (s, t, { planning }) => {
+runner.registerScenario('record deletion API', async (s, t) => {
+  const { planning } = await s.players({ planning: config }, true)
+
   // write records
   const commitment = {
     note: 'a commitment to provide something',
   }
-  const commitmentResponse = await planning.call('commitment', 'create_commitment', { commitment })
+  const commitmentResponse = await planning.call('planning', 'commitment', 'create_commitment', { commitment })
   t.ok(commitmentResponse.Ok.commitment && commitmentResponse.Ok.commitment.id, 'commitment created successfully')
-  await s.consistent()
+  await s.consistency()
   const commitmentId = commitmentResponse.Ok.commitment.id
 
   // attempt retrieval
-  let readResp = await planning.call('commitment', 'get_commitment', { address: commitmentId })
+  let readResp = await planning.call('planning', 'commitment', 'get_commitment', { address: commitmentId })
   t.equal(readResp.Ok.commitment.id, commitmentId, 'record not retrievable')
 
   // perform deletion
-  const delResp = await planning.call('commitment', 'delete_commitment', { address: commitmentId })
+  const delResp = await planning.call('planning', 'commitment', 'delete_commitment', { address: commitmentId })
   t.ok(delResp.Ok, 'record deleted successfully')
-  await s.consistent()
+  await s.consistency()
 
   // attempt retrieval
-  readResp = await planning.call('commitment', 'get_commitment', { address: commitmentId })
+  readResp = await planning.call('planning', 'commitment', 'get_commitment', { address: commitmentId })
   t.equal(readResp.Err.Internal, 'No entry at this address', 'record not retrievable once deleted')
 })
 
@@ -36,9 +39,9 @@ runner.registerScenario('Cannot delete records of a different type via zome API 
   const commitment = {
     note: 'a commitment to provide something',
   }
-  const commitmentResponse = await planning.call('commitment', 'create_commitment', { commitment })
+  const commitmentResponse = await planning.call('planning', 'commitment', 'create_commitment', { commitment })
   t.ok(commitmentResponse.Ok.commitment && commitmentResponse.Ok.commitment.id, 'commitment created successfully')
-  await s.consistent()
+  await s.consistency()
   const commitmentId = commitmentResponse.Ok.commitment.id
 
   const fulfillment = {
@@ -46,13 +49,13 @@ runner.registerScenario('Cannot delete records of a different type via zome API 
     fulfilledBy: commitmentId,  // erroneous but doesn't matter for now
     note: 'fulfillment indicating the relationship',
   }
-  const fulfillmentResp = await planning.call('fulfillment', 'create_fulfillment', { fulfillment })
+  const fulfillmentResp = await planning.call('planning', 'fulfillment', 'create_fulfillment', { fulfillment })
   t.ok(fulfillmentResp.Ok.fulfillment && fulfillmentResp.Ok.fulfillment.id, 'fulfillment created successfully')
-  await s.consistent()
+  await s.consistency()
   const fulfillmentId = fulfillmentResp.Ok.fulfillment.id
 
   // attempt to delete commitment via fulfillment deletion API
-  const delResp = await planning.call('fulfillment', 'delete_fulfillment', { address: commitmentId })
+  const delResp = await planning.call('planning', 'fulfillment', 'delete_fulfillment', { address: commitmentId })
   t.equal(delResp.Err.ValidationFailed, 'incorrect record type specified for deletion')
 })
 

--- a/test/core-architecture/test_record_field_update.js
+++ b/test/core-architecture/test_record_field_update.js
@@ -1,30 +1,33 @@
 const {
   getDNA,
-  buildOrchestrator,
+  buildConfig,
+  runner,
 } = require('../init')
 
-const runner = buildOrchestrator({
+const config = buildConfig({
   observation: getDNA('observation'),
 })
 
-runner.registerScenario('updates with fields ommitted leave original value intact', async (s, t, { observation }) => {
+runner.registerScenario('updates with fields ommitted leave original value intact', async (s, t) => {
+  const { observation } = await s.players({ observation: config }, true)
+
   const event = {
     note: 'test event',
     action: 'produce',
   }
 
-  const createEventResponse = await observation.call('economic_event', 'create_event', { event })
+  const createEventResponse = await observation.call('observation', 'economic_event', 'create_event', { event })
   t.ok(createEventResponse.Ok.economicEvent && createEventResponse.Ok.economicEvent.id, 'record created successfully')
-  await s.consistent()
+  await s.consistency()
 
-  const updateEventResponse = await observation.call('economic_event', 'update_event', {
+  const updateEventResponse = await observation.call('observation', 'economic_event', 'update_event', {
     event: {
       id: createEventResponse.Ok.economicEvent.id,
     },
   })
-  await s.consistent()
+  await s.consistency()
 
-  const readResponse = await observation.call('economic_event', 'get_event', { address: createEventResponse.Ok.economicEvent.id })
+  const readResponse = await observation.call('observation', 'economic_event', 'get_event', { address: createEventResponse.Ok.economicEvent.id })
   t.equal(readResponse.Ok.economicEvent.note, 'test event', 'field remains if not provided')
 })
 
@@ -34,20 +37,20 @@ runner.registerScenario('updates with fields nulled remove original value', asyn
     action: 'produce',
   }
 
-  const createEventResponse = await observation.call('economic_event', 'create_event', { event })
+  const createEventResponse = await observation.call('observation', 'economic_event', 'create_event', { event })
   t.ok(createEventResponse.Ok.economicEvent && createEventResponse.Ok.economicEvent.id, 'record created successfully')
-  await s.consistent()
+  await s.consistency()
 
-  const updateEventResponse = await observation.call('economic_event', 'update_event', {
+  const updateEventResponse = await observation.call('observation', 'economic_event', 'update_event', {
     event: {
       id: createEventResponse.Ok.economicEvent.id,
       action: 'produce',
       note: null,
     },
   })
-  await s.consistent()
+  await s.consistency()
 
-  const readResponse = await observation.call('economic_event', 'get_event', { address: createEventResponse.Ok.economicEvent.id })
+  const readResponse = await observation.call('observation', 'economic_event', 'get_event', { address: createEventResponse.Ok.economicEvent.id })
   t.equal(readResponse.Ok.economicEvent.note, undefined, 'field removed if nulled')
 })
 

--- a/test/core-architecture/test_record_id_behaviours.js
+++ b/test/core-architecture/test_record_id_behaviours.js
@@ -1,30 +1,33 @@
 const {
   getDNA,
-  buildOrchestrator,
+  buildConfig,
+  runner,
 } = require('../init')
 
-const runner = buildOrchestrator({
+const config = buildConfig({
   observation: getDNA('observation'),
 })
 
-runner.registerScenario('records have stable IDs after update', async (s, t, { observation }) => {
+runner.registerScenario('records have stable IDs after update', async (s, t) => {
+  const { observation } = await s.players({ observation: config }, true)
+
   const event = {
     note: 'test event',
     action: 'produce',
   }
 
-  const createEventResponse = await observation.call('economic_event', 'create_event', { event })
+  const createEventResponse = await observation.call('observation', 'economic_event', 'create_event', { event })
 
   t.ok(createEventResponse.Ok.economicEvent && createEventResponse.Ok.economicEvent.id, 'record created successfully')
 
-  const updateEventResponse = await observation.call('economic_event', 'update_event', {
+  const updateEventResponse = await observation.call('observation', 'economic_event', 'update_event', {
     event: {
       id: createEventResponse.Ok.economicEvent.id,
       note: 'updated event',
     },
   })
 
-  await s.consistent()
+  await s.consistency()
 
   t.equal(createEventResponse.Ok.economicEvent.id, updateEventResponse.Ok.economicEvent.id, 'ID consistent after update')
   t.equal(updateEventResponse.Ok.economicEvent.note, 'updated event', 'field update OK')
@@ -36,26 +39,26 @@ runner.registerScenario('records can be updated multiple times with same ID', as
     action: 'produce',
   }
 
-  const createResp = await observation.call('economic_event', 'create_event', { event })
+  const createResp = await observation.call('observation', 'economic_event', 'create_event', { event })
 
-  await observation.call('economic_event', 'update_event', {
+  await observation.call('observation', 'economic_event', 'update_event', {
     event: {
       id: createResp.Ok.economicEvent.id,
       note: 'event v2',
     },
   })
-  const updateResp2 = await observation.call('economic_event', 'update_event', {
+  const updateResp2 = await observation.call('observation', 'economic_event', 'update_event', {
     event: {
       id: createResp.Ok.economicEvent.id,
       note: 'event v3',
     },
   })
 
-  await s.consistent()
+  await s.consistency()
 
   t.ok(updateResp2.Ok.economicEvent, 'subsequent update successful')
   t.equal(updateResp2.Ok.economicEvent.note, 'event v3', 'subsequent field update OK')
-  t.equal(createResp.Ok.economicEvent.id, updateResp2.Ok.economicEvent.id, 'ID consistent after subsequent update')
+  t.equal(createResp.Ok.economicEvent.id, updateResp2.Ok.economicEvent.id, 'ID consistency after subsequent update')
 })
 
 runner.run()

--- a/test/core-architecture/test_record_links_cross_dna.js
+++ b/test/core-architecture/test_record_links_cross_dna.js
@@ -1,60 +1,63 @@
 const {
   getDNA,
-  buildOrchestrator,
+  buildConfig,
+  runner,
 } = require('../init')
 
-const runner = buildOrchestrator({
+const config = buildConfig({
   observation: getDNA('observation'),
   planning: getDNA('planning'),
 }, {
   vf_observation: ['planning', 'observation'],
 })
 
-runner.registerScenario('updating remote link fields syncs fields and associated indexes', async (s, t, { observation, planning }) => {
+runner.registerScenario('updating remote link fields syncs fields and associated indexes', async (s, t) => {
+  const { alice } = await s.players({ alice: config }, true)
+
   // SCENARIO: write initial records
   const process = {
     name: 'context record for testing relationships',
   }
-  const pResp = await observation.call('process', 'create_process', { process })
+  const pResp = await alice.call('observation', 'process', 'create_process', { process })
   t.ok(pResp.Ok.process && pResp.Ok.process.id, 'target record created successfully')
-  await s.consistent()
+  await s.consistency()
   const processId = pResp.Ok.process.id
 
   const process2 = {
     name: 'second context record for testing relationships',
   }
-  const pResp2 = await observation.call('process', 'create_process', { process: process2 })
+  const pResp2 = await alice.call('observation', 'process', 'create_process', { process: process2 })
   t.ok(pResp2.Ok.process && pResp2.Ok.process.id, 'secondary record created successfully')
-  await s.consistent()
+  await s.consistency()
   const differentProcessId = pResp2.Ok.process.id
 
   const iCommitment = {
     note: 'test input commitment',
     inputOf: processId,
   }
-  const icResp = await planning.call('commitment', 'create_commitment', { commitment: iCommitment })
+  const icResp = await alice.call('planning', 'commitment', 'create_commitment', { commitment: iCommitment })
   t.ok(icResp.Ok.commitment && icResp.Ok.commitment.id, 'input record created successfully')
   t.equal(icResp.Ok.commitment.inputOf, processId, 'field reference OK in write')
-  await s.consistent()
+  await s.consistency()
   const iCommitmentId = icResp.Ok.commitment.id
 
   // ASSERT: test forward link field
-  let readResponse = await planning.call('commitment', 'get_commitment', { address: iCommitmentId })
+  let readResponse = await alice.call('planning', 'commitment', 'get_commitment', { address: iCommitmentId })
   t.equal(readResponse.Ok.commitment && readResponse.Ok.commitment.inputOf, processId, 'field reference OK on read')
 
   // ASSERT: test reciprocal link field
-  readResponse = await observation.call('process', 'get_process', { address: processId })
+  readResponse = await alice.call('observation', 'process', 'get_process', { address: processId })
   t.equal(readResponse.Ok.process
     && readResponse.Ok.process.committedInputs
     && readResponse.Ok.process.committedInputs[0], iCommitmentId, 'reciprocal field reference OK on read')
 
   // ASSERT: test commitment input query edge
-  readResponse = await planning.call('commitment', 'query_commitments', { params: { inputOf: processId } })
+  readResponse = await alice.call('planning', 'commitment', 'query_commitments', { params: { inputOf: processId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'field query index present')
   t.equal(readResponse.Ok && readResponse.Ok[0] && readResponse.Ok[0].commitment && readResponse.Ok[0].commitment.id, iCommitmentId, 'query index OK')
 
   // ASSERT: test process input query edge
-  readResponse = await observation.call('process', 'query_processes', { params: { committedInputs: iCommitmentId } })
+  readResponse = await alice.call('observation', 'process', 'query_processes', { params: { committedInputs: iCommitmentId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'reciprocal query index present')
   t.equal(readResponse.Ok && readResponse.Ok[0] && readResponse.Ok[0].process && readResponse.Ok[0].process.id, processId, 'reciprocal query index OK')
 
@@ -65,27 +68,27 @@ runner.registerScenario('updating remote link fields syncs fields and associated
     id: iCommitmentId,
     inputOf: differentProcessId,
   }
-  const ieResp2 = await planning.call('commitment', 'update_commitment', { commitment: updateCommitment })
+  const ieResp2 = await alice.call('planning', 'commitment', 'update_commitment', { commitment: updateCommitment })
   t.equal(ieResp2.Ok.commitment && ieResp2.Ok.commitment.inputOf, differentProcessId, 'record link field updated successfully')
-  await s.consistent()
+  await s.consistency()
 
   // ASSERT: test commitment fields
-  readResponse = await planning.call('commitment', 'get_commitment', { address: iCommitmentId })
+  readResponse = await alice.call('planning', 'commitment', 'get_commitment', { address: iCommitmentId })
   t.ok(readResponse.Ok.commitment && readResponse.Ok.commitment.inputOf, 'field reference OK on read')
   t.equal(readResponse.Ok.commitment && readResponse.Ok.commitment.inputOf, differentProcessId, 'field updated successfully')
 
   // ASSERT: test new commitment input query edge
-  readResponse = await planning.call('commitment', 'query_commitments', { params: { inputOf: differentProcessId } })
+  readResponse = await alice.call('planning', 'commitment', 'query_commitments', { params: { inputOf: differentProcessId } })
   t.equal(readResponse.Ok && readResponse.Ok[0]
     && readResponse.Ok[0].commitment
     && readResponse.Ok[0].commitment.id, iCommitmentId, 'new field query index applied')
 
   // ASSERT: test stale commitment input query edge
-  readResponse = await planning.call('commitment', 'query_commitments', { params: { inputOf: processId } })
+  readResponse = await alice.call('planning', 'commitment', 'query_commitments', { params: { inputOf: processId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 0, 'stale field query index removed')
 
   // ASSERT: test process input query edge
-  readResponse = await observation.call('process', 'query_processes', { params: { committedInputs: iCommitmentId } })
+  readResponse = await alice.call('observation', 'process', 'query_processes', { params: { committedInputs: iCommitmentId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'reciprocal query index count ok')
   t.equal(readResponse.Ok && readResponse.Ok[0]
     && readResponse.Ok[0].process
@@ -94,12 +97,12 @@ runner.registerScenario('updating remote link fields syncs fields and associated
 
 
   // SCENARIO: update link field (no-op)
-  const ieResp3 = await planning.call('commitment', 'update_commitment', { commitment: updateCommitment })
+  const ieResp3 = await alice.call('planning', 'commitment', 'update_commitment', { commitment: updateCommitment })
   t.equal(ieResp3.Ok.commitment && ieResp3.Ok.commitment.inputOf, differentProcessId, 'update with same fields is no-op')
-  await s.consistent()
+  await s.consistency()
 
   // ASSERT: test event fields
-  readResponse = await planning.call('commitment', 'get_commitment', { address: iCommitmentId })
+  readResponse = await alice.call('planning', 'commitment', 'get_commitment', { address: iCommitmentId })
   t.equal(readResponse.Ok.commitment && readResponse.Ok.commitment.inputOf, differentProcessId, 'field update no-op OK')
 
 
@@ -109,20 +112,20 @@ runner.registerScenario('updating remote link fields syncs fields and associated
     id: iCommitmentId,
     inputOf: null,
   }
-  const ieResp4 = await planning.call('commitment', 'update_commitment', { commitment: wipeEventInput })
+  const ieResp4 = await alice.call('planning', 'commitment', 'update_commitment', { commitment: wipeEventInput })
   t.equal(ieResp4.Ok.commitment && ieResp4.Ok.commitment.inputOf, undefined, 'update with null value erases field')
-  await s.consistent()
+  await s.consistency()
 
   // ASSERT: test event fields
-  readResponse = await planning.call('commitment', 'get_commitment', { address: iCommitmentId })
+  readResponse = await alice.call('planning', 'commitment', 'get_commitment', { address: iCommitmentId })
   t.equal(readResponse.Ok.commitment && readResponse.Ok.commitment.inputOf, undefined, 'field erased successfully')
 
   // ASSERT: test event input query edge
-  readResponse = await planning.call('commitment', 'query_commitments', { params: { inputOf: differentProcessId } })
+  readResponse = await alice.call('planning', 'commitment', 'query_commitments', { params: { inputOf: differentProcessId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 0, 'field query index updated')
 
   // ASSERT: test process input query edge
-  readResponse = await observation.call('process', 'query_processes', { params: { committedInputs: iCommitmentId } })
+  readResponse = await alice.call('observation', 'process', 'query_processes', { params: { committedInputs: iCommitmentId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 0, 'reciprocal field query index updated')
 
 
@@ -131,68 +134,70 @@ runner.registerScenario('updating remote link fields syncs fields and associated
   // :TODO: updates for fields when other values are present in the index array
 })
 
-runner.registerScenario('removing records with linked remote indexes clears them in associated records', async (s, t, { observation, planning }) => {
+runner.registerScenario('removing records with linked remote indexes clears them in associated records', async (s, t) => {
+  const { alice } = await s.players({ alice: config }, true)
+
   // SCENARIO: write initial records
   const process = {
     name: 'context record for testing relationships',
   }
-  const pResp = await observation.call('process', 'create_process', { process })
+  const pResp = await alice.call('observation', 'process', 'create_process', { process })
   t.ok(pResp.Ok.process && pResp.Ok.process.id, 'record created successfully')
-  await s.consistent()
+  await s.consistency()
   const processId = pResp.Ok.process.id
 
   const iIntent = {
     note: 'test input intent',
     inputOf: processId,
   }
-  const iiResp = await planning.call('intent', 'create_intent', { intent: iIntent })
+  const iiResp = await alice.call('planning', 'intent', 'create_intent', { intent: iIntent })
   t.ok(iiResp.Ok.intent && iiResp.Ok.intent.id, 'input record created successfully')
   t.equal(iiResp.Ok.intent.inputOf, processId, 'field reference OK in write')
-  await s.consistent()
+  await s.consistency()
   const iIntentId = iiResp.Ok.intent.id
 
   // ASSERT: test forward link field
-  let readResponse = await planning.call('intent', 'get_intent', { address: iIntentId })
+  let readResponse = await alice.call('planning', 'intent', 'get_intent', { address: iIntentId })
   t.equal(readResponse.Ok.intent && readResponse.Ok.intent.inputOf, processId, 'field reference OK on read')
 
   // ASSERT: test reciprocal link field
-  readResponse = await observation.call('process', 'get_process', { address: processId })
+  readResponse = await alice.call('observation', 'process', 'get_process', { address: processId })
   t.equal(readResponse.Ok.process
     && readResponse.Ok.process.intendedInputs
     && readResponse.Ok.process.intendedInputs[0], iIntentId, 'reciprocal field reference OK on read')
 
   // ASSERT: test commitment input query edge
-  readResponse = await planning.call('intent', 'query_intents', { params: { inputOf: processId } })
+  readResponse = await alice.call('planning', 'intent', 'query_intents', { params: { inputOf: processId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'field query index present')
   t.equal(readResponse.Ok && readResponse.Ok[0] && readResponse.Ok[0].intent && readResponse.Ok[0].intent.id, iIntentId, 'query index OK')
 
   // ASSERT: test process input query edge
-  readResponse = await observation.call('process', 'query_processes', { params: { intendedInputs: iIntentId } })
+  readResponse = await alice.call('observation', 'process', 'query_processes', { params: { intendedInputs: iIntentId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'reciprocal query index present')
   t.equal(readResponse.Ok && readResponse.Ok[0] && readResponse.Ok[0].process && readResponse.Ok[0].process.id, processId, 'reciprocal query index OK')
 
 
 
   // SCENARIO: wipe associated record
-  const delResp = await planning.call('intent', 'delete_intent', { address: iIntentId })
+  const delResp = await alice.call('planning', 'intent', 'delete_intent', { address: iIntentId })
   t.ok(delResp.Ok, 'input record deleted')
-  await s.consistent()
+  await s.consistency()
 
   // ASSERT: test forward link field
-  readResponse = await planning.call('intent', 'get_intent', { address: iIntentId })
+  readResponse = await alice.call('planning', 'intent', 'get_intent', { address: iIntentId })
   t.equal(readResponse.Err && readResponse.Err.Internal, 'No entry at this address', 'record deletion OK')
 
   // ASSERT: test reciprocal link field
-  readResponse = await observation.call('process', 'get_process', { address: processId })
+  readResponse = await alice.call('observation', 'process', 'get_process', { address: processId })
   t.equal(readResponse.Ok.process
     && readResponse.Ok.process.intendedInputs.length, 0, 'reciprocal field reference removed')
 
   // ASSERT: test commitment input query edge
-  readResponse = await planning.call('intent', 'query_intents', { params: { inputOf: processId } })
+  readResponse = await alice.call('planning', 'intent', 'query_intents', { params: { inputOf: processId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 0, 'field query index removed')
 
   // ASSERT: test process input query edge
-  readResponse = await observation.call('process', 'query_processes', { params: { intendedInputs: iIntentId } })
+  readResponse = await alice.call('observation', 'process', 'query_processes', { params: { intendedInputs: iIntentId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 0, 'reciprocal query index removed')
 })
 

--- a/test/core-architecture/test_record_links_cross_zome.js
+++ b/test/core-architecture/test_record_links_cross_zome.js
@@ -2,32 +2,35 @@
 // hence why there are special test cases for this.
 const {
   getDNA,
-  buildOrchestrator,
+  buildConfig,
+  runner,
 } = require('../init')
 
-const runner = buildOrchestrator({
+const config = buildConfig({
   observation: getDNA('observation'),
   planning: getDNA('planning'),
 }, {
   vf_observation: ['planning', 'observation'],
 })
 
-runner.registerScenario('updating local link fields syncs fields and associated indexes', async (s, t, { observation }) => {
+runner.registerScenario('updating local link fields syncs fields and associated indexes', async (s, t) => {
+  const { alice } = await s.players({ alice: config }, true)
+
   // SCENARIO: write initial records
   const process = {
     name: 'context process for testing relationships',
   }
-  const pResp = await observation.call('process', 'create_process', { process })
+  const pResp = await alice.call('observation', 'process', 'create_process', { process })
   t.ok(pResp.Ok.process && pResp.Ok.process.id, 'process created successfully')
-  await s.consistent()
+  await s.consistency()
   const processId = pResp.Ok.process.id
 
   const process2 = {
     name: 'second context process for testing relationships',
   }
-  const pResp2 = await observation.call('process', 'create_process', { process: process2 })
+  const pResp2 = await alice.call('observation', 'process', 'create_process', { process: process2 })
   t.ok(pResp2.Ok.process && pResp2.Ok.process.id, 'process created successfully')
-  await s.consistent()
+  await s.consistency()
   const differentProcessId = pResp2.Ok.process.id
 
   const iEvent = {
@@ -35,23 +38,23 @@ runner.registerScenario('updating local link fields syncs fields and associated 
     action: 'produce',
     inputOf: processId,
   }
-  const ieResp = await observation.call('economic_event', 'create_event', { event: iEvent })
+  const ieResp = await alice.call('observation', 'economic_event', 'create_event', { event: iEvent })
   t.ok(ieResp.Ok.economicEvent && ieResp.Ok.economicEvent.id, 'input record created successfully')
   t.equal(ieResp.Ok.economicEvent.inputOf, processId, 'field reference OK in write')
-  await s.consistent()
+  await s.consistency()
   const iEventId = ieResp.Ok.economicEvent.id
 
   // ASSERT: test event fields
-  let readResponse = await observation.call('economic_event', 'get_event', { address: iEventId })
+  let readResponse = await alice.call('observation', 'economic_event', 'get_event', { address: iEventId })
   t.equal(readResponse.Ok.economicEvent && readResponse.Ok.economicEvent.inputOf, processId, 'field reference OK on read')
 
   // ASSERT: test event input query edge
-  readResponse = await observation.call('economic_event', 'query_events', { params: { inputOf: processId } })
+  readResponse = await alice.call('observation', 'economic_event', 'query_events', { params: { inputOf: processId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'field query index present')
   t.equal(readResponse.Ok[0] && readResponse.Ok[0].economicEvent && readResponse.Ok[0].economicEvent.id, iEventId, 'query index OK')
 
   // ASSERT: test process input query edge
-  readResponse = await observation.call('process', 'query_processes', { params: { inputs: iEventId } })
+  readResponse = await alice.call('observation', 'process', 'query_processes', { params: { inputs: iEventId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'reciprocal query index present')
   t.equal(readResponse.Ok[0] && readResponse.Ok[0].process && readResponse.Ok[0].process.id, processId, 'reciprocal query index OK')
 
@@ -62,34 +65,34 @@ runner.registerScenario('updating local link fields syncs fields and associated 
     id: iEventId,
     inputOf: differentProcessId,
   }
-  const ieResp2 = await observation.call('economic_event', 'update_event', { event: updateEvent })
+  const ieResp2 = await alice.call('observation', 'economic_event', 'update_event', { event: updateEvent })
   t.equal(ieResp2.Ok.economicEvent && ieResp2.Ok.economicEvent.inputOf, differentProcessId, 'record link field updated successfully')
-  await s.consistent()
+  await s.consistency()
 
   // ASSERT: test event fields
-  readResponse = await observation.call('economic_event', 'get_event', { address: iEventId })
+  readResponse = await alice.call('observation', 'economic_event', 'get_event', { address: iEventId })
   t.ok(readResponse.Ok.economicEvent && readResponse.Ok.economicEvent.inputOf, 'field reference OK on read')
   t.equal(readResponse.Ok.economicEvent && readResponse.Ok.economicEvent.inputOf, differentProcessId, 'field updated successfully')
 
   // ASSERT: test event input query edge
-  readResponse = await observation.call('economic_event', 'query_events', { params: { inputOf: differentProcessId } })
+  readResponse = await alice.call('observation', 'economic_event', 'query_events', { params: { inputOf: differentProcessId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'field query index present')
   t.equal(readResponse.Ok[0] && readResponse.Ok[0].economicEvent && readResponse.Ok[0].economicEvent.id, iEventId, 'field query index updated')
 
   // ASSERT: test process input query edge
-  readResponse = await observation.call('process', 'query_processes', { params: { inputs: iEventId } })
+  readResponse = await alice.call('observation', 'process', 'query_processes', { params: { inputs: iEventId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'process query index present')
   t.equal(readResponse.Ok[0] && readResponse.Ok[0].process && readResponse.Ok[0].process.id, differentProcessId, 'process query index updated')
 
 
 
   // SCENARIO: update link field (no-op)
-  const ieResp3 = await observation.call('economic_event', 'update_event', { event: updateEvent })
+  const ieResp3 = await alice.call('observation', 'economic_event', 'update_event', { event: updateEvent })
   t.equal(ieResp3.Ok.economicEvent && ieResp3.Ok.economicEvent.inputOf, differentProcessId, 'update with same fields is no-op')
-  await s.consistent()
+  await s.consistency()
 
   // ASSERT: test event fields
-  readResponse = await observation.call('economic_event', 'get_event', { address: iEventId })
+  readResponse = await alice.call('observation', 'economic_event', 'get_event', { address: iEventId })
   t.equal(readResponse.Ok.economicEvent && readResponse.Ok.economicEvent.inputOf, differentProcessId, 'field update no-op OK')
 
 
@@ -99,20 +102,20 @@ runner.registerScenario('updating local link fields syncs fields and associated 
     id: iEventId,
     inputOf: null,
   }
-  const ieResp4 = await observation.call('economic_event', 'update_event', { event: wipeEventInput })
+  const ieResp4 = await alice.call('observation', 'economic_event', 'update_event', { event: wipeEventInput })
   t.equal(ieResp4.Ok.economicEvent && ieResp4.Ok.economicEvent.inputOf, undefined, 'update with null value erases field')
-  await s.consistent()
+  await s.consistency()
 
   // ASSERT: test event fields
-  readResponse = await observation.call('economic_event', 'get_event', { address: iEventId })
+  readResponse = await alice.call('observation', 'economic_event', 'get_event', { address: iEventId })
   t.equal(readResponse.Ok.economicEvent && readResponse.Ok.economicEvent.inputOf, undefined, 'field erased successfully')
 
   // ASSERT: test event input query edge
-  readResponse = await observation.call('economic_event', 'query_events', { params: { inputOf: differentProcessId } })
+  readResponse = await alice.call('observation', 'economic_event', 'query_events', { params: { inputOf: differentProcessId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 0, 'field query index updated')
 
   // ASSERT: test process input query edge
-  readResponse = await observation.call('process', 'query_processes', { params: { inputs: iEventId } })
+  readResponse = await alice.call('observation', 'process', 'query_processes', { params: { inputs: iEventId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 0, 'process query index updated')
 
 
@@ -122,11 +125,11 @@ runner.registerScenario('updating local link fields syncs fields and associated 
     action: 'produce',
     inputOf: "notarealprocess",
   }
-  const badResp = await observation.call('economic_event', 'create_event', { event: badEvent })
+  const badResp = await alice.call('observation', 'economic_event', 'create_event', { event: badEvent })
   // :TODO: should result in an error and avoid creating the entry if any invalid fields are provided
   // :TODO: this involves having a deep think about how much transactionality we want to enforce!
   t.equal(badResp.Ok.economicEvent && badResp.Ok.economicEvent.inputOf, undefined, 'create with bad value is ignored')
-  await s.consistent()
+  await s.consistency()
 
 
 
@@ -134,13 +137,15 @@ runner.registerScenario('updating local link fields syncs fields and associated 
 })
 
 runner.registerScenario('removing records with linked local indexes clears them in associated records', async (s, t, { observation }) => {
+  const { alice } = await s.players({ alice: config }, true)
+
   // SCENARIO: write initial records
   const process = {
     name: 'context record for testing relationships',
   }
-  const pResp = await observation.call('process', 'create_process', { process })
+  const pResp = await alice.call('observation', 'process', 'create_process', { process })
   t.ok(pResp.Ok.process && pResp.Ok.process.id, 'context record created successfully')
-  await s.consistent()
+  await s.consistency()
   const processId = pResp.Ok.process.id
 
   const iEvent = {
@@ -148,54 +153,54 @@ runner.registerScenario('removing records with linked local indexes clears them 
     action: 'produce',
     inputOf: processId,
   }
-  const ieResp = await observation.call('economic_event', 'create_event', { event: iEvent })
+  const ieResp = await alice.call('observation', 'economic_event', 'create_event', { event: iEvent })
   t.ok(ieResp.Ok.economicEvent && ieResp.Ok.economicEvent.id, 'input record created successfully')
   t.equal(ieResp.Ok.economicEvent.inputOf, processId, 'field reference OK in write')
-  await s.consistent()
+  await s.consistency()
   const iEventId = ieResp.Ok.economicEvent.id
 
   // ASSERT: test forward link field
-  let readResponse = await observation.call('economic_event', 'get_event', { address: iEventId })
+  let readResponse = await alice.call('observation', 'economic_event', 'get_event', { address: iEventId })
   t.equal(readResponse.Ok.economicEvent && readResponse.Ok.economicEvent.inputOf, processId, 'field reference OK on read')
 
   // ASSERT: test reciprocal link field
-  readResponse = await observation.call('process', 'get_process', { address: processId })
+  readResponse = await alice.call('observation', 'process', 'get_process', { address: processId })
   t.equal(readResponse.Ok.process
     && readResponse.Ok.process.inputs
     && readResponse.Ok.process.inputs[0], iEventId, 'reciprocal field reference OK on read')
 
   // ASSERT: test commitment input query edge
-  readResponse = await observation.call('economic_event', 'query_events', { params: { inputOf: processId } })
+  readResponse = await alice.call('observation', 'economic_event', 'query_events', { params: { inputOf: processId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'field query index present')
   t.equal(readResponse.Ok && readResponse.Ok[0] && readResponse.Ok[0].economicEvent && readResponse.Ok[0].economicEvent.id, iEventId, 'query index OK')
 
   // ASSERT: test process input query edge
-  readResponse = await observation.call('process', 'query_processes', { params: { inputs: iEventId } })
+  readResponse = await alice.call('observation', 'process', 'query_processes', { params: { inputs: iEventId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'reciprocal query index present')
   t.equal(readResponse.Ok && readResponse.Ok[0] && readResponse.Ok[0].process && readResponse.Ok[0].process.id, processId, 'reciprocal query index OK')
 
 
 
   // SCENARIO: wipe associated record
-  const delResp = await observation.call('economic_event', 'delete_event', { address: iEventId })
+  const delResp = await alice.call('observation', 'economic_event', 'delete_event', { address: iEventId })
   t.ok(delResp.Ok, 'input record deleted')
-  await s.consistent()
+  await s.consistency()
 
   // ASSERT: test forward link field
-  readResponse = await observation.call('economic_event', 'get_event', { address: iEventId })
+  readResponse = await alice.call('observation', 'economic_event', 'get_event', { address: iEventId })
   t.equal(readResponse.Err && readResponse.Err.Internal, 'No entry at this address', 'record deletion OK')
 
   // ASSERT: test reciprocal link field
-  readResponse = await observation.call('process', 'get_process', { address: processId })
+  readResponse = await alice.call('observation', 'process', 'get_process', { address: processId })
   t.equal(readResponse.Ok.process
     && readResponse.Ok.process.inputs.length, 0, 'reciprocal field reference removed')
 
   // ASSERT: test commitment input query edge
-  readResponse = await observation.call('economic_event', 'query_events', { params: { inputOf: processId } })
+  readResponse = await alice.call('observation', 'economic_event', 'query_events', { params: { inputOf: processId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 0, 'field query index removed')
 
   // ASSERT: test process input query edge
-  readResponse = await observation.call('process', 'query_processes', { params: { inputs: iEventId } })
+  readResponse = await alice.call('observation', 'process', 'query_processes', { params: { inputs: iEventId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 0, 'reciprocal query index removed')
 })
 

--- a/test/economic-event/test_basic_ops.js
+++ b/test/economic-event/test_basic_ops.js
@@ -1,20 +1,23 @@
 const {
   getDNA,
-  buildOrchestrator,
+  buildConfig,
+  runner,
 } = require('../init')
 
-const runner = buildOrchestrator({
+const config = buildConfig({
   observation: getDNA('observation'),
 })
 
-runner.registerScenario('create simplest event', async (s, t, { observation }) => {
+runner.registerScenario('create simplest event', async (s, t) => {
+  const { alice } = await s.players({ alice: config }, true)
+
   const event = {
     note: 'test event',
   }
 
-  const createEventResponse = await observation.call('economic_event', 'create_event', { event })
+  const createEventResponse = await alice.call('observation', 'economic_event', 'create_event', { event })
 
-  await s.consistent()
+  await s.consistency()
 
   console.log(require('util').inspect(createEventResponse, { depth: null, colors: true }))
 })

--- a/test/economic-resource/resource_links.js
+++ b/test/economic-resource/resource_links.js
@@ -1,14 +1,17 @@
 const {
   getDNA,
-  buildOrchestrator,
+  buildConfig,
+  runner,
 } = require('../init')
 
-const runner = buildOrchestrator({
+const config = buildConfig({
   observation: getDNA('observation'),
 }, {
 })
 
-runner.registerScenario('EconomicResource composition / containment functionality', async (s, t, { observation }) => {
+runner.registerScenario('EconomicResource composition / containment functionality', async (s, t) => {
+  const { alice } = await s.players({ alice: config }, true)
+
   // SCENARIO: write initial records
   const resourceSpecificationId = 'dangling-resource-specification-todo-tidy-up'
   const inputEvent = {
@@ -19,8 +22,8 @@ runner.registerScenario('EconomicResource composition / containment functionalit
     note: 'container resource',
     conformsTo: resourceSpecificationId,
   }
-  const cResp1 = await observation.call('economic_event', 'create_event', { event: inputEvent, new_inventoried_resource: inputResource })
-  await s.consistent()
+  const cResp1 = await alice.call('observation', 'economic_event', 'create_event', { event: inputEvent, new_inventoried_resource: inputResource })
+  await s.consistency()
   const event1 = cResp1.Ok.economicEvent;
   const resource1 = cResp1.Ok.economicResource;
   t.ok(event1.id, 'event created successfully')
@@ -37,19 +40,19 @@ runner.registerScenario('EconomicResource composition / containment functionalit
     conformsTo: resourceSpecificationId,
     note: 'internal resource',
   }
-  const cResp2 = await observation.call('economic_event', 'create_event', { event: inputEvent2, new_inventoried_resource: inputResource2 })
-  await s.consistent()
+  const cResp2 = await alice.call('observation', 'economic_event', 'create_event', { event: inputEvent2, new_inventoried_resource: inputResource2 })
+  await s.consistency()
   t.ok(cResp2.Ok, 'internal resource created successfully')
   const resource2 = cResp2.Ok.economicResource;
   const resourceId2 = resource2.id
 
-  let readResp = await observation.call('economic_resource', 'get_resource', { address: resourceId1 })
+  let readResp = await alice.call('observation', 'economic_resource', 'get_resource', { address: resourceId1 })
   let readResource = readResp.Ok.economicResource
   t.ok(readResource.id, 'container resource retrieval OK')
   t.equal(readResource.contains && readResource.contains.length, 1, 'container resource reference inserted')
   t.equal(readResource.contains && readResource.contains[0], resourceId2, 'container resource reference OK')
 
-  readResp = await observation.call('economic_resource', 'get_resource', { address: resourceId2 })
+  readResp = await alice.call('observation', 'economic_resource', 'get_resource', { address: resourceId2 })
   readResource = readResp.Ok.economicResource
   t.ok(readResource.id, 'contained resource retrieval OK')
   t.equal(readResource.containedIn, resourceId1, 'contained resource reference OK')
@@ -65,13 +68,13 @@ runner.registerScenario('EconomicResource composition / containment functionalit
     conformsTo: resourceSpecificationId,
     note: 'another internal resource',
   }
-  const cResp3 = await observation.call('economic_event', 'create_event', { event: inputEvent3, new_inventoried_resource: inputResource3 })
-  await s.consistent()
+  const cResp3 = await alice.call('observation', 'economic_event', 'create_event', { event: inputEvent3, new_inventoried_resource: inputResource3 })
+  await s.consistency()
   t.ok(cResp3.Ok, 'additional internal resource created successfully')
   const resource3 = cResp3.Ok.economicResource;
   const resourceId3 = resource3.id
 
-  readResp = await observation.call('economic_resource', 'get_resource', { address: resourceId1 })
+  readResp = await alice.call('observation', 'economic_resource', 'get_resource', { address: resourceId1 })
   readResource = readResp.Ok.economicResource
   t.ok(readResource.id, 'container resource re-retrieval OK')
   t.equal(readResource.contains && readResource.contains.length, 2, 'container resource reference appended')
@@ -85,11 +88,11 @@ runner.registerScenario('EconomicResource composition / containment functionalit
     containedIn: null,
     note: 'standalone resource',
   }
-  const uResp3 = await observation.call('economic_resource', 'update_resource', { resource: updateResource3 })
-  await s.consistent()
+  const uResp3 = await alice.call('observation', 'economic_resource', 'update_resource', { resource: updateResource3 })
+  await s.consistency()
   t.ok(uResp3.Ok, 'internal resource updated successfully')
 
-  readResp = await observation.call('economic_resource', 'get_resource', { address: resourceId1 })
+  readResp = await alice.call('observation', 'economic_resource', 'get_resource', { address: resourceId1 })
   readResource = readResp.Ok.economicResource
   t.ok(readResource.id, 'container resource re-retrieval OK')
   t.equal(readResource.contains && readResource.contains.length, 1, 'container resource reference removed after update')
@@ -100,11 +103,11 @@ runner.registerScenario('EconomicResource composition / containment functionalit
 
   // SCENARIO: delete resource, check links are removed
   // :TODO: needs some thought
-  // const dResp = await observation.call('economic_resource', 'delete_resource', { address: resourceId3 })
-  // await s.consistent()
+  // const dResp = await alice.call('observation', 'economic_resource', 'delete_resource', { address: resourceId3 })
+  // await s.consistency()
   // t.ok(dResp.Ok, 'resource deleted successfully')
 
-  // readResp = await observation.call('economic_resource', 'get_resource', { address: resourceId1 })
+  // readResp = await alice.call('observation', 'economic_resource', 'get_resource', { address: resourceId1 })
   // readResource = readResp.Ok.economicResource
   // t.ok(readResource.id, 'container resource re-retrieval OK')
   // t.equal(readResource.contains && readResource.contains.length, 0, 'container resource reference removed after deletion')

--- a/test/flows/flow_records_graphql.js
+++ b/test/flows/flow_records_graphql.js
@@ -1,0 +1,63 @@
+const {
+  getDNA,
+  buildConfig,
+  runner,
+  graphQL,
+} = require('../init')
+
+const config = buildConfig({
+  observation: getDNA('observation'),
+  planning: getDNA('planning'),
+}, {
+  vf_observation: ['planning', 'observation'],
+})
+
+runner.registerScenario('flow records and relationships', async (s, t) => {
+  const { alice } = await s.players({ alice: config }, true)
+
+  const cResp = await graphQL(`
+    mutation(
+      $event: EconomicEventCreateParams!,
+      $commitment: CommitmentCreateParams!,
+      $intent: IntentCreateParams!
+    ) {
+      createIntent(intent: $intent) {
+        intent {
+          id
+        }
+      }
+      createCommitment(commitment: $commitment) {
+        commitment {
+          id
+        }
+      }
+      createEconomicEvent(event:$event) {
+        economicEvent {
+          id
+        }
+      }
+    }
+  `, {
+    "intent": {
+      "action": "produce",
+      "note": "please make the thing happen"
+    },
+    "commitment": {
+      "action": "produce",
+      "note": "I'll make the thing happen"
+    },
+    "event": {
+      "action": "produce",
+      "note": "hooray, the thing happened!"
+    },
+  })
+
+  await s.consistency()
+
+  t.ok(cResp.data.createIntent.intent.id, "intent created OK")
+  t.ok(cResp.data.createCommitment.commitment.id, "commitment created OK")
+  t.ok(cResp.data.createEconomicEvent.economicEvent.id, "event created OK")
+
+})
+
+runner.run()

--- a/test/fulfillment/fulfillment_records_e2e.js
+++ b/test/fulfillment/fulfillment_records_e2e.js
@@ -1,32 +1,35 @@
 const {
   getDNA,
-  buildOrchestrator,
+  buildConfig,
+  runner,
 } = require('../init')
 
-const runner = buildOrchestrator({
+const config = buildConfig({
   observation: getDNA('observation'),
   planning: getDNA('planning'),
 }, {
   vf_observation: ['planning', 'observation'],
 })
 
-runner.registerScenario('links can be written and read between DNAs', async (s, t, { planning, observation }) => {
+runner.registerScenario('links can be written and read between DNAs', async (s, t) => {
+  const { alice } = await s.players({ alice: config }, true)
+
   // SCENARIO: write records
   const commitment = {
     note: 'a commitment to provide something',
   }
-  const commitmentResponse = await planning.call('commitment', 'create_commitment', { commitment })
+  const commitmentResponse = await alice.call('planning', 'commitment', 'create_commitment', { commitment })
   t.ok(commitmentResponse.Ok.commitment && commitmentResponse.Ok.commitment.id, 'commitment created successfully')
-  await s.consistent()
+  await s.consistency()
   const commitmentId = commitmentResponse.Ok.commitment.id
 
   const event = {
     note: 'test event which is fulfilling a commitment',
     action: 'produce',
   }
-  const eventResp = await observation.call('economic_event', 'create_event', { event })
+  const eventResp = await alice.call('observation', 'economic_event', 'create_event', { event })
   t.ok(eventResp.Ok.economicEvent && eventResp.Ok.economicEvent.id, 'event created successfully')
-  await s.consistent()
+  await s.consistency()
   const eventId = eventResp.Ok.economicEvent.id
 
   const fulfillment = {
@@ -34,40 +37,40 @@ runner.registerScenario('links can be written and read between DNAs', async (s, 
     fulfilledBy: eventId,
     note: 'fulfillment indicating the relationship',
   }
-  const fulfillmentResp = await planning.call('fulfillment', 'create_fulfillment', { fulfillment })
+  const fulfillmentResp = await alice.call('planning', 'fulfillment', 'create_fulfillment', { fulfillment })
   t.ok(fulfillmentResp.Ok.fulfillment && fulfillmentResp.Ok.fulfillment.id, 'fulfillment created successfully')
-  await s.consistent()
+  await s.consistency()
   const fulfillmentId = fulfillmentResp.Ok.fulfillment.id
 
   // ASSERT: check fulfillment in originating network
-  let readResponse = await planning.call('fulfillment', 'get_fulfillment', { address: fulfillmentId })
+  let readResponse = await alice.call('planning', 'fulfillment', 'get_fulfillment', { address: fulfillmentId })
   t.equal(readResponse.Ok.fulfillment.fulfilledBy, eventId, 'Fulfillment.fulfilledBy reference saved')
   t.equal(readResponse.Ok.fulfillment.fulfills, commitmentId, 'Fulfillment.fulfills reference saved')
 
   // ASSERT: check event
-  readResponse = await observation.call('economic_event', 'get_event', { address: eventId })
+  readResponse = await alice.call('observation', 'economic_event', 'get_event', { address: eventId })
   t.ok(readResponse.Ok.economicEvent.fulfills, 'EconomicEvent.fulfills value present')
   t.equal(readResponse.Ok.economicEvent.fulfills.length, 1, 'EconomicEvent.fulfills reference saved')
   t.equal(readResponse.Ok.economicEvent.fulfills[0], fulfillmentId, 'EconomicEvent.fulfills reference OK')
 
   // ASSERT: check commitment
-  readResponse = await planning.call('commitment', 'get_commitment', { address: commitmentId })
+  readResponse = await alice.call('planning', 'commitment', 'get_commitment', { address: commitmentId })
   t.ok(readResponse.Ok.commitment.fulfilledBy, 'Commitment.fulfilledBy reciprocal value present')
   t.equal(readResponse.Ok.commitment.fulfilledBy.length, 1, 'Commitment.fulfilledBy reciprocal reference saved')
   t.equal(readResponse.Ok.commitment.fulfilledBy[0], fulfillmentId, 'Commitment.fulfilledBy reciprocal fulfillment reference OK')
 
   // ASSERT: check fulfillment in target network
-  readResponse = await observation.call('fulfillment', 'get_fulfillment', { address: fulfillmentId })
+  readResponse = await alice.call('observation', 'fulfillment', 'get_fulfillment', { address: fulfillmentId })
   t.equal(readResponse.Ok.fulfillment.fulfilledBy, eventId, 'Fulfillment.fulfilledBy reference saved')
   t.equal(readResponse.Ok.fulfillment.fulfills, commitmentId, 'Fulfillment.fulfills reference saved')
 
   // ASSERT: check forward query indexes
-  readResponse = await planning.call('fulfillment', 'query_fulfillments', { params: { fulfills: commitmentId } })
+  readResponse = await alice.call('planning', 'fulfillment', 'query_fulfillments', { params: { fulfills: commitmentId } })
   t.equal(readResponse.Ok.length, 1, 'read fulfillments by commitment OK')
   t.equal(readResponse.Ok[0].fulfillment.id, fulfillmentId, 'Fulfillment.fulfills indexed correctly')
 
   // ASSERT: check reverse query indexes
-  readResponse = await observation.call('fulfillment', 'query_fulfillments', { params: { fulfilledBy: eventId } })
+  readResponse = await alice.call('observation', 'fulfillment', 'query_fulfillments', { params: { fulfilledBy: eventId } })
   t.equal(readResponse.Ok.length, 1, 'read fulfillments by event OK')
   t.equal(readResponse.Ok[0].fulfillment.id, fulfillmentId, 'Fulfillment.fulfilledBy indexed correctly')
 
@@ -79,41 +82,41 @@ runner.registerScenario('links can be written and read between DNAs', async (s, 
     fulfilledBy: eventId,
     note: 'fulfillment indicating another relationship',
   }
-  const fulfillmentResp2 = await planning.call('fulfillment', 'create_fulfillment', { fulfillment: fulfillment2 })
+  const fulfillmentResp2 = await alice.call('planning', 'fulfillment', 'create_fulfillment', { fulfillment: fulfillment2 })
   t.ok(fulfillmentResp2.Ok.fulfillment && fulfillmentResp2.Ok.fulfillment.id, 'additional fulfillment created successfully')
-  await s.consistent()
+  await s.consistency()
   const fulfillmentId2 = fulfillmentResp2.Ok.fulfillment.id
 
   // ASSERT: check forward query indices
-  readResponse = await planning.call('fulfillment', 'query_fulfillments', { params: { fulfills: commitmentId } })
+  readResponse = await alice.call('planning', 'fulfillment', 'query_fulfillments', { params: { fulfills: commitmentId } })
   t.equal(readResponse.Ok.length, 2, 'appending fulfillments for read OK')
   t.equal(readResponse.Ok[0].fulfillment.id, fulfillmentId, 'fulfillment 1 indexed correctly')
   t.equal(readResponse.Ok[1].fulfillment.id, fulfillmentId2, 'fulfillment 2 indexed correctly')
 
   // ASSERT: ensure append is working on the event read side
-  readResponse = await observation.call('economic_event', 'get_event', { address: eventId })
+  readResponse = await alice.call('observation', 'economic_event', 'get_event', { address: eventId })
   t.equal(readResponse.Ok.economicEvent.fulfills.length, 2, 'EconomicEvent.fulfills appending OK')
   t.equal(readResponse.Ok.economicEvent.fulfills[0], fulfillmentId, 'EconomicEvent.fulfills reference 1 OK')
   t.equal(readResponse.Ok.economicEvent.fulfills[1], fulfillmentId2, 'EconomicEvent.fulfills reference 2 OK')
 
   // ASSERT: ensure query indices on the event read side
-  readResponse = await observation.call('economic_event', 'query_events', { params: { fulfills: fulfillmentId } })
+  readResponse = await alice.call('observation', 'economic_event', 'query_events', { params: { fulfills: fulfillmentId } })
   t.equal(readResponse.Ok.length, 1, 'appending fulfillments for event query OK')
   t.equal(readResponse.Ok[0].economicEvent.id, eventId, 'event query indexed correctly')
 
   // ASSERT: ensure append is working on the commitment read side
-  readResponse = await planning.call('commitment', 'get_commitment', { address: commitmentId })
+  readResponse = await alice.call('planning', 'commitment', 'get_commitment', { address: commitmentId })
   t.equal(readResponse.Ok.commitment.fulfilledBy.length, 2, 'Commitment.fulfilledBy appending OK')
   t.equal(readResponse.Ok.commitment.fulfilledBy[0], fulfillmentId, 'Commitment.fulfilledBy reference 1 OK')
   t.equal(readResponse.Ok.commitment.fulfilledBy[1], fulfillmentId2, 'Commitment.fulfilledBy reference 2 OK')
 
   // ASSERT: ensure query indices on the commitment read side
-  readResponse = await planning.call('commitment', 'query_commitments', { params: { fulfilledBy: fulfillmentId } })
+  readResponse = await alice.call('planning', 'commitment', 'query_commitments', { params: { fulfilledBy: fulfillmentId } })
   t.equal(readResponse.Ok.length, 1, 'appending fulfillments for commitment query OK')
   t.equal(readResponse.Ok[0].commitment.id, commitmentId, 'commitment query indexed correctly')
 
   // ASSERT: check reciprocal query indexes
-  readResponse = await observation.call('fulfillment', 'query_fulfillments', { params: { fulfilledBy: eventId } })
+  readResponse = await alice.call('observation', 'fulfillment', 'query_fulfillments', { params: { fulfilledBy: eventId } })
   t.equal(readResponse.Ok.length, 2, 'read fulfillments by event OK')
   t.equal(readResponse.Ok[0].fulfillment.id, fulfillmentId, 'fulfillment 1 indexed correctly')
   t.equal(readResponse.Ok[1].fulfillment.id, fulfillmentId2, 'fulfillment 2 indexed correctly')

--- a/test/init.js
+++ b/test/init.js
@@ -51,7 +51,7 @@ const buildConfig = (instances, bridges) => Config.genConfig({
     b.push(Config.bridge(bridgeId, ...bridges[bridgeId]))
     return b
   }, []),
-  network: "memory",
+  network: "n3h",
 }, {
   logger: process.env.VERBOSE_DNA_DEBUG ? true : false,
 })

--- a/test/init.js
+++ b/test/init.js
@@ -5,10 +5,24 @@
  * @flow
  */
 
+// :TODO: need to implement per-agent GraphQL query interface via dynamic websocket port bindings
+const WEBSOCKET_PORT = 4001
+process.env.REACT_APP_HC_CONN_URL = `ws://localhost:${WEBSOCKET_PORT}`
+
+const os = require('os')
+const fs = require('fs')
 const path = require('path')
 const tape = require('tape')
+const getPort = require('get-port')
 
-const { Diorama, tapeExecutor } = require('@holochain/diorama')
+const { Orchestrator, Config, tapeExecutor, combine } = require('@holochain/try-o-rama')
+
+const GQLTester = require('easygraphql-tester')
+const { all_vf: schema } = require('@valueflows/vf-graphql/typeDefs')
+const resolvers = require('@valueflows/vf-graphql-holochain/build/resolvers')
+
+// :SHONK: workaround TS compiler props
+delete resolvers['__esModule']
 
 process.on('unhandledRejection', error => {
   console.error('unhandled rejection:', error)
@@ -19,7 +33,7 @@ process.on('unhandledRejection', error => {
 })
 
 // DNA loader, to be used with `buildTestScenario` when constructing DNAs for testing
-const getDNA = ((dnas) => (path) => (Diorama.dna(dnas[path], path)))({
+const getDNA = ((dnas) => (path) => (Config.dna(dnas[path], path)))({
   'observation': path.resolve(__dirname, '../happs/observation/dist/observation.dna.json'),
   'planning': path.resolve(__dirname, '../happs/planning/dist/planning.dna.json'),
 })
@@ -29,19 +43,59 @@ const getDNA = ((dnas) => (path) => (Diorama.dna(dnas[path], path)))({
  *
  * @param  {object} instances mapping of instance IDs to DNAs (@see getDNA)
  * @param  {object} bridges   (optional) mapping of bridge IDs to DNA instance ID pairs
- * @return Diorama instance for testing
+ * @return Try-o-rama config instance for creating 'players'
  */
-const buildOrchestrator = (instances, bridges) => new Diorama({
+const buildConfig = (instances, bridges) => Config.genConfig({
   instances,
   bridges: Object.keys(bridges || {}).reduce((b, bridgeId) => {
-    b.push(Diorama.bridge(bridgeId, ...bridges[bridgeId]))
+    b.push(Config.bridge(bridgeId, ...bridges[bridgeId]))
     return b
   }, []),
-  debugLog: process.env.VERBOSE_DNA_DEBUG || false,
-  executor: tapeExecutor(tape),
+  network: "memory",
+}, {
+  logger: process.env.VERBOSE_DNA_DEBUG || false,
 })
+
+/**
+ * Temporary directory handling for conductor orchestrator
+ * (needed due to overriding of genConfigArgs to set websocket port for GraphQL client bindings)
+ */
+const mkdirIdempotent = async (dir) => {
+  try {
+    await fs.access(dir)
+  } catch (e) {
+    fs.mkdirSync(dir, { recursive: true })
+  }
+}
+const tempDirBase = path.join(os.tmpdir(), 'try-o-rama/')
+const tempDir = async () => {
+    await mkdirIdempotent(tempDirBase)
+    return fs.mkdtempSync(tempDirBase)
+}
+
+/**
+ * Create a test scenario orchestrator instance
+ */
+const runner = new Orchestrator({
+  genConfigArgs: async (conductorName, uuid) => ({
+    conductorName,
+    uuid,
+    configDir: await tempDir(),
+    adminPort: await getPort(),
+    zomePort: WEBSOCKET_PORT,  // :TODO: allow multiple agents to be interacted with via multiple websocket ports
+  }),
+  middleware: combine(tapeExecutor(tape)),
+})
+
+/**
+ * GraphQL client interface connected to scenario websocket connection
+ */
+const tester = new GQLTester(schema, resolvers)
+const graphQL = (query, params) => tester.graphql(query, undefined, undefined, params)
 
 module.exports = {
   getDNA,
-  buildOrchestrator,
+  buildConfig,
+  runner,
+  graphQL,
 }

--- a/test/init.js
+++ b/test/init.js
@@ -53,7 +53,7 @@ const buildConfig = (instances, bridges) => Config.genConfig({
   }, []),
   network: "memory",
 }, {
-  logger: process.env.VERBOSE_DNA_DEBUG || false,
+  logger: process.env.VERBOSE_DNA_DEBUG ? true : false,
 })
 
 /**

--- a/test/init.js
+++ b/test/init.js
@@ -64,7 +64,11 @@ const mkdirIdempotent = async (dir) => {
   try {
     await fs.access(dir)
   } catch (e) {
-    fs.mkdirSync(dir, { recursive: true })
+    try {
+      fs.mkdirSync(dir, { recursive: true })
+    } catch (e) {
+      console.warn(e)
+    }
   }
 }
 const tempDirBase = path.join(os.tmpdir(), 'try-o-rama/')

--- a/test/package.json
+++ b/test/package.json
@@ -7,13 +7,18 @@
     "test": "tape test_*.js **/*.js | faucet"
   },
   "devDependencies": {
-    "@holochain/diorama": "0.2.0-rc.1",
+    "@holochain/try-o-rama": "0.1.2-beta.4",
+    "@valueflows/vf-graphql": "0.0.1",
+    "@valueflows/vf-graphql-holochain": "0.0.1",
+    "easygraphql-tester": "5.1.6",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.17.3",
     "eslint-plugin-node": "^9.1.0",
     "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-standard": "^4.0.0",
     "faucet": "^0.0.1",
+    "get-port": "5.0.0",
+    "graphql": "14.5.8",
     "json3": "^3.3.2",
     "tape": "^4.9.2"
   },

--- a/test/package.json
+++ b/test/package.json
@@ -20,6 +20,7 @@
     "get-port": "5.0.0",
     "graphql": "14.5.8",
     "json3": "^3.3.2",
+    "n3h": "github:holochain/n3h#0.0.20-alpha",
     "tape": "^4.9.2"
   },
   "repository": {

--- a/test/process/process_records_e2e.js
+++ b/test/process/process_records_e2e.js
@@ -1,23 +1,26 @@
 const {
   getDNA,
-  buildOrchestrator,
+  buildConfig,
+  runner,
 } = require('../init')
 
-const runner = buildOrchestrator({
+const config = buildConfig({
   observation: getDNA('observation'),
   planning: getDNA('planning'),
 }, {
   vf_observation: ['planning', 'observation'],
 })
 
-runner.registerScenario('process query indexes and relationships', async (s, t, { planning, observation }) => {
+runner.registerScenario('process query indexes and relationships', async (s, t) => {
+  const { alice } = await s.players({ alice: config }, true)
+
   // SCENARIO: write records
   const process = {
     name: 'test process for linking logic',
   }
-  const pResp = await observation.call('process', 'create_process', { process })
+  const pResp = await alice.call('observation', 'process', 'create_process', { process })
   t.ok(pResp.Ok.process && pResp.Ok.process.id, 'process created successfully')
-  await s.consistent()
+  await s.consistency()
   const processId = pResp.Ok.process.id
 
   const iEvent = {
@@ -25,10 +28,10 @@ runner.registerScenario('process query indexes and relationships', async (s, t, 
     action: 'consume',
     inputOf: processId,
   }
-  const ieResp = await observation.call('economic_event', 'create_event', { event: iEvent })
+  const ieResp = await alice.call('observation', 'economic_event', 'create_event', { event: iEvent })
   t.ok(ieResp.Ok.economicEvent && ieResp.Ok.economicEvent.id, 'input event created successfully')
   t.equal(ieResp.Ok.economicEvent.inputOf, processId, 'event.inputOf reference OK in write')
-  await s.consistent()
+  await s.consistency()
   const iEventId = ieResp.Ok.economicEvent.id
 
   const oEvent = {
@@ -36,145 +39,145 @@ runner.registerScenario('process query indexes and relationships', async (s, t, 
     action: 'produce',
     outputOf: processId,
   }
-  const oeResp = await observation.call('economic_event', 'create_event', { event: oEvent })
+  const oeResp = await alice.call('observation', 'economic_event', 'create_event', { event: oEvent })
   t.ok(oeResp.Ok.economicEvent && oeResp.Ok.economicEvent.id, 'output event created successfully')
   t.equal(oeResp.Ok.economicEvent.outputOf, processId, 'event.outputOf reference OK in write')
-  await s.consistent()
+  await s.consistency()
   const oEventId = oeResp.Ok.economicEvent.id
 
   const iCommitment = {
     note: 'test input commitment',
     inputOf: processId,
   }
-  const icResp = await planning.call('commitment', 'create_commitment', { commitment: iCommitment })
+  const icResp = await alice.call('planning', 'commitment', 'create_commitment', { commitment: iCommitment })
   t.ok(icResp.Ok.commitment && icResp.Ok.commitment.id, 'input commitment created successfully')
   t.equal(icResp.Ok.commitment.inputOf, processId, 'commitment.inputOf reference OK in write')
-  await s.consistent()
+  await s.consistency()
   const iCommitmentId = icResp.Ok.commitment.id
 
   const oCommitment = {
     note: 'test output commitment',
     outputOf: processId,
   }
-  const ocResp = await planning.call('commitment', 'create_commitment', { commitment: oCommitment })
+  const ocResp = await alice.call('planning', 'commitment', 'create_commitment', { commitment: oCommitment })
   t.ok(ocResp.Ok.commitment && ocResp.Ok.commitment.id, 'output commitment created successfully')
   t.equal(ocResp.Ok.commitment.outputOf, processId, 'commitment.outputOf reference OK in write')
-  await s.consistent()
+  await s.consistency()
   const oCommitmentId = ocResp.Ok.commitment.id
 
   const iIntent = {
     note: 'test input intent',
     inputOf: processId,
   }
-  const iiResp = await planning.call('intent', 'create_intent', { intent: iIntent })
+  const iiResp = await alice.call('planning', 'intent', 'create_intent', { intent: iIntent })
   t.ok(iiResp.Ok.intent && iiResp.Ok.intent.id, 'input intent created successfully')
   t.equal(iiResp.Ok.intent.inputOf, processId, 'intent.inputOf reference OK in write')
-  await s.consistent()
+  await s.consistency()
   const iIntentId = iiResp.Ok.intent.id
 
   const oIntent = {
     note: 'test output intent',
     outputOf: processId,
   }
-  const oiResp = await planning.call('intent', 'create_intent', { intent: oIntent })
+  const oiResp = await alice.call('planning', 'intent', 'create_intent', { intent: oIntent })
   t.ok(oiResp.Ok.intent && oiResp.Ok.intent.id, 'output intent created successfully')
   t.equal(oiResp.Ok.intent.outputOf, processId, 'intent.outputOf reference OK in write')
-  await s.consistent()
+  await s.consistency()
   const oIntentId = oiResp.Ok.intent.id
 
 
 
   // ASSERT: check input event index links
-  readResponse = await observation.call('economic_event', 'get_event', { address: iEventId })
+  readResponse = await alice.call('observation', 'economic_event', 'get_event', { address: iEventId })
   t.ok(readResponse.Ok.economicEvent && readResponse.Ok.economicEvent.inputOf, 'EconomicEvent.inputOf index saved')
   t.equal(readResponse.Ok.economicEvent && readResponse.Ok.economicEvent.inputOf, processId, 'EconomicEvent.inputOf reference OK in read')
 
   // ASSERT: check output event index links
-  readResponse = await observation.call('economic_event', 'get_event', { address: oEventId })
+  readResponse = await alice.call('observation', 'economic_event', 'get_event', { address: oEventId })
   t.ok(readResponse.Ok.economicEvent && readResponse.Ok.economicEvent.outputOf, 'EconomicEvent.outputOf index saved')
   t.equal(readResponse.Ok.economicEvent && readResponse.Ok.economicEvent.outputOf, processId, 'EconomicEvent.outputOf reference OK in read')
 
   // ASSERT: test event input query edge
-  readResponse = await observation.call('economic_event', 'query_events', { params: { inputOf: processId } })
+  readResponse = await alice.call('observation', 'economic_event', 'query_events', { params: { inputOf: processId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'event input query index present')
   t.equal(readResponse.Ok[0] && readResponse.Ok[0].economicEvent && readResponse.Ok[0].economicEvent.id, iEventId, 'event input query index created')
 
   // ASSERT: test event output query edge
-  readResponse = await observation.call('economic_event', 'query_events', { params: { outputOf: processId } })
+  readResponse = await alice.call('observation', 'economic_event', 'query_events', { params: { outputOf: processId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'event output query index present')
   t.equal(readResponse.Ok[0] && readResponse.Ok[0].economicEvent && readResponse.Ok[0].economicEvent.id, oEventId, 'event output query index created')
 
   // ASSERT: check process event input query edge
-  readResponse = await observation.call('process', 'query_processes', { params: { inputs: iEventId } })
+  readResponse = await alice.call('observation', 'process', 'query_processes', { params: { inputs: iEventId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'process.inputs query succeeded')
   t.equal(readResponse.Ok[0] && readResponse.Ok[0].process && readResponse.Ok[0].process.id, processId, 'process.inputs query index created')
 
   // ASSERT: check process event output query edge
-  readResponse = await observation.call('process', 'query_processes', { params: { outputs: oEventId } })
+  readResponse = await alice.call('observation', 'process', 'query_processes', { params: { outputs: oEventId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'process.outputs query succeeded')
   t.equal(readResponse.Ok[0] && readResponse.Ok[0].process && readResponse.Ok[0].process.id, processId, 'process.outputs query index created')
 
 
 
   // ASSERT: check input commitment index links
-  readResponse = await planning.call('commitment', 'get_commitment', { address: iCommitmentId })
+  readResponse = await alice.call('planning', 'commitment', 'get_commitment', { address: iCommitmentId })
   t.ok(readResponse.Ok.commitment && readResponse.Ok.commitment.inputOf, 'commitment.inputOf index saved')
   t.equal(readResponse.Ok.commitment && readResponse.Ok.commitment.inputOf, processId, 'commitment.inputOf reference OK in read')
 
   // ASSERT: check output commitment index links
-  readResponse = await planning.call('commitment', 'get_commitment', { address: oCommitmentId })
+  readResponse = await alice.call('planning', 'commitment', 'get_commitment', { address: oCommitmentId })
   t.ok(readResponse.Ok.commitment && readResponse.Ok.commitment.outputOf, 'commitment.outputOf index saved')
   t.equal(readResponse.Ok.commitment && readResponse.Ok.commitment.outputOf, processId, 'commitment.outputOf reference OK in read')
 
   // ASSERT: test commitment input query edge
-  readResponse = await planning.call('commitment', 'query_commitments', { params: { inputOf: processId } })
+  readResponse = await alice.call('planning', 'commitment', 'query_commitments', { params: { inputOf: processId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'commitment input query index present')
   t.equal(readResponse.Ok[0] && readResponse.Ok[0].commitment && readResponse.Ok[0].commitment.id, iCommitmentId, 'commitment input query index created')
 
   // ASSERT: test commitment output query edge
-  readResponse = await planning.call('commitment', 'query_commitments', { params: { outputOf: processId } })
+  readResponse = await alice.call('planning', 'commitment', 'query_commitments', { params: { outputOf: processId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'commitment output query index present')
   t.equal(readResponse.Ok[0] && readResponse.Ok[0].commitment && readResponse.Ok[0].commitment.id, oCommitmentId, 'commitment output query index created')
 
   // ASSERT: check process commitment input query edge
-  readResponse = await observation.call('process', 'query_processes', { params: { committedInputs: iCommitmentId } })
+  readResponse = await alice.call('observation', 'process', 'query_processes', { params: { committedInputs: iCommitmentId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'process.committedInputs query succeeded')
   t.equal(readResponse.Ok[0] && readResponse.Ok[0].process && readResponse.Ok[0].process.id, processId, 'process.committedInputs query index created')
 
   // ASSERT: check process commitment output query edge
-  readResponse = await observation.call('process', 'query_processes', { params: { committedOutputs: oCommitmentId } })
+  readResponse = await alice.call('observation', 'process', 'query_processes', { params: { committedOutputs: oCommitmentId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'process.committedOutputs query succeeded')
   t.equal(readResponse.Ok[0] && readResponse.Ok[0].process && readResponse.Ok[0].process.id, processId, 'process.committedOutputs query index created')
 
 
 
   // ASSERT: check input intent index links
-  readResponse = await planning.call('intent', 'get_intent', { address: iIntentId })
+  readResponse = await alice.call('planning', 'intent', 'get_intent', { address: iIntentId })
   t.ok(readResponse.Ok.intent && readResponse.Ok.intent.inputOf, 'intent.inputOf index saved')
   t.equal(readResponse.Ok.intent && readResponse.Ok.intent.inputOf, processId, 'intent.inputOf reference OK in read')
 
   // ASSERT: check output intent index links
-  readResponse = await planning.call('intent', 'get_intent', { address: oIntentId })
+  readResponse = await alice.call('planning', 'intent', 'get_intent', { address: oIntentId })
   t.ok(readResponse.Ok.intent && readResponse.Ok.intent.outputOf, 'intent.outputOf index saved')
   t.equal(readResponse.Ok.intent && readResponse.Ok.intent.outputOf, processId, 'intent.outputOf reference OK in read')
 
   // ASSERT: test intent input query edge
-  readResponse = await planning.call('intent', 'query_intents', { params: { inputOf: processId } })
+  readResponse = await alice.call('planning', 'intent', 'query_intents', { params: { inputOf: processId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'intent input query index present')
   t.equal(readResponse.Ok[0] && readResponse.Ok[0].intent && readResponse.Ok[0].intent.id, iIntentId, 'intent input query index created')
 
   // ASSERT: test intent output query edge
-  readResponse = await planning.call('intent', 'query_intents', { params: { outputOf: processId } })
+  readResponse = await alice.call('planning', 'intent', 'query_intents', { params: { outputOf: processId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'intent output query index present')
   t.equal(readResponse.Ok[0] && readResponse.Ok[0].intent && readResponse.Ok[0].intent.id, oIntentId, 'intent output query index created')
 
   // ASSERT: check process intent input query edge
-  readResponse = await observation.call('process', 'query_processes', { params: { intendedInputs: iIntentId } })
+  readResponse = await alice.call('observation', 'process', 'query_processes', { params: { intendedInputs: iIntentId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'process.intendedInputs query succeeded')
   t.equal(readResponse.Ok[0] && readResponse.Ok[0].process && readResponse.Ok[0].process.id, processId, 'process.intendedInputs query index created')
 
   // ASSERT: check process intent output query edge
-  readResponse = await observation.call('process', 'query_processes', { params: { intendedOutputs: oIntentId } })
+  readResponse = await alice.call('observation', 'process', 'query_processes', { params: { intendedOutputs: oIntentId } })
   t.equal(readResponse.Ok && readResponse.Ok.length, 1, 'process.intendedOutputs query succeeded')
   t.equal(readResponse.Ok[0] && readResponse.Ok[0].process && readResponse.Ok[0].process.id, processId, 'process.intendedOutputs query index created')
 

--- a/test/satisfaction/satisfaction_records_e2e.js
+++ b/test/satisfaction/satisfaction_records_e2e.js
@@ -1,32 +1,35 @@
 const {
   getDNA,
-  buildOrchestrator,
+  buildConfig,
+  runner,
 } = require('../init')
 
-const runner = buildOrchestrator({
+const config = buildConfig({
   observation: getDNA('observation'),
   planning: getDNA('planning'),
 }, {
   vf_observation: ['planning', 'observation'],
 })
 
-runner.registerScenario('satisfactions can be written and read between DNAs by all parties requiring access', async (s, t, { planning, observation }) => {
+runner.registerScenario('satisfactions can be written and read between DNAs by all parties requiring access', async (s, t) => {
+  const { alice } = await s.players({ alice: config }, true)
+
   // SCENARIO: write records
   const intent = {
     note: 'an intent to provide something',
   }
-  const intentResponse = await planning.call('intent', 'create_intent', { intent })
+  const intentResponse = await alice.call('planning', 'intent', 'create_intent', { intent })
   t.ok(intentResponse.Ok.intent && intentResponse.Ok.intent.id, 'intent created successfully')
-  await s.consistent()
+  await s.consistency()
   const intentId = intentResponse.Ok.intent.id
 
   const event = {
     note: 'test event which is satisfying an intent',
     action: 'produce',
   }
-  const eventResp = await observation.call('economic_event', 'create_event', { event })
+  const eventResp = await alice.call('observation', 'economic_event', 'create_event', { event })
   t.ok(eventResp.Ok.economicEvent && eventResp.Ok.economicEvent.id, 'event created successfully')
-  await s.consistent()
+  await s.consistency()
   const eventId = eventResp.Ok.economicEvent.id
 
   const satisfaction = {
@@ -34,50 +37,50 @@ runner.registerScenario('satisfactions can be written and read between DNAs by a
     satisfiedBy: eventId,
     note: 'satisfied by an event',
   }
-  const satisfactionResp = await planning.call('satisfaction', 'create_satisfaction', { satisfaction })
+  const satisfactionResp = await alice.call('planning', 'satisfaction', 'create_satisfaction', { satisfaction })
   t.ok(satisfactionResp.Ok.satisfaction && satisfactionResp.Ok.satisfaction.id, 'satisfaction by event created successfully')
-  await s.consistent()
+  await s.consistency()
   const satisfactionId = satisfactionResp.Ok.satisfaction.id
 
   // ASSERT: check satisfaction in originating network
-  let readResponse = await planning.call('satisfaction', 'get_satisfaction', { address: satisfactionId })
+  let readResponse = await alice.call('planning', 'satisfaction', 'get_satisfaction', { address: satisfactionId })
   t.equal(readResponse.Ok.satisfaction.satisfiedBy, eventId, 'Satisfaction.satisfiedBy reference saved')
   t.equal(readResponse.Ok.satisfaction.satisfies, intentId, 'Satisfaction.satisfies reference saved')
 
   // ASSERT: check satisfaction in target network
-  readResponse = await observation.call('satisfaction', 'get_satisfaction', { address: satisfactionId })
+  readResponse = await alice.call('observation', 'satisfaction', 'get_satisfaction', { address: satisfactionId })
   t.equal(readResponse.Ok.satisfaction.satisfiedBy, eventId, 'Satisfaction.satisfiedBy reference saved')
   t.equal(readResponse.Ok.satisfaction.satisfies, intentId, 'Satisfaction.satisfies reference saved')
 
   // ASSERT: check event field refs
-  readResponse = await observation.call('economic_event', 'get_event', { address: eventId })
+  readResponse = await alice.call('observation', 'economic_event', 'get_event', { address: eventId })
   t.ok(readResponse.Ok.economicEvent.satisfies, 'EconomicEvent.satisfies value present')
   t.equal(readResponse.Ok.economicEvent.satisfies.length, 1, 'EconomicEvent.satisfies reference saved')
   t.equal(readResponse.Ok.economicEvent.satisfies[0], satisfactionId, 'EconomicEvent.satisfies reference OK')
 
   // ASSERT: check intent field refs
-  readResponse = await planning.call('intent', 'get_intent', { address: intentId })
+  readResponse = await alice.call('planning', 'intent', 'get_intent', { address: intentId })
   t.ok(readResponse.Ok.intent.satisfiedBy, 'intent.satisfiedBy reciprocal value present')
   t.equal(readResponse.Ok.intent.satisfiedBy.length, 1, 'Intent.satisfiedBy reciprocal reference saved')
   t.equal(readResponse.Ok.intent.satisfiedBy[0], satisfactionId, 'Intent.satisfiedBy reciprocal satisfaction reference OK')
 
   // ASSERT: check intent query indexes
-  readResponse = await planning.call('satisfaction', 'query_satisfactions', { params: { satisfies: intentId } })
+  readResponse = await alice.call('planning', 'satisfaction', 'query_satisfactions', { params: { satisfies: intentId } })
   t.equal(readResponse.Ok.length, 1, 'read satisfactions by intent OK')
   t.equal(readResponse.Ok[0].satisfaction.id, satisfactionId, 'Satisfaction.satisfies indexed correctly')
 
   // ASSERT: check event query indexes
-  readResponse = await observation.call('satisfaction', 'query_satisfactions', { params: { satisfiedBy: eventId } })
+  readResponse = await alice.call('observation', 'satisfaction', 'query_satisfactions', { params: { satisfiedBy: eventId } })
   t.equal(readResponse.Ok.length, 1, 'read satisfactions by event OK')
   t.equal(readResponse.Ok[0].satisfaction.id, satisfactionId, 'Satisfaction.satisfiedBy indexed correctly')
 
   // ASSERT: check intent satisfaction query indexes
-  readResponse = await planning.call('intent', 'query_intents', { params: { satisfiedBy: satisfactionId } })
+  readResponse = await alice.call('planning', 'intent', 'query_intents', { params: { satisfiedBy: satisfactionId } })
   t.equal(readResponse.Ok.length, 1, 'indexing satisfactions for intent query OK')
   t.equal(readResponse.Ok[0].intent.id, intentId, 'intent query 1 indexed correctly')
 
   // ASSERT: check event satisfaction query indexes
-  readResponse = await observation.call('economic_event', 'query_events', { params: { satisfies: satisfactionId } })
+  readResponse = await alice.call('observation', 'economic_event', 'query_events', { params: { satisfies: satisfactionId } })
   t.equal(readResponse.Ok.length, 1, 'indexing satisfactions for event query OK')
   t.equal(readResponse.Ok[0].economicEvent.id, eventId, 'event query 1 indexed correctly')
 
@@ -87,9 +90,9 @@ runner.registerScenario('satisfactions can be written and read between DNAs by a
   const commitment = {
     note: 'test commitment which is satisfying an intent',
   }
-  const commitmentResp = await planning.call('commitment', 'create_commitment', { commitment })
+  const commitmentResp = await alice.call('planning', 'commitment', 'create_commitment', { commitment })
   t.ok(commitmentResp.Ok.commitment && commitmentResp.Ok.commitment.id, 'commitment created successfully')
-  await s.consistent()
+  await s.consistency()
   const commitmentId = commitmentResp.Ok.commitment.id
 
   const satisfaction2 = {
@@ -97,36 +100,36 @@ runner.registerScenario('satisfactions can be written and read between DNAs by a
     satisfiedBy: commitmentId,
     note: 'satisfied by a commitment',
   }
-  const satisfactionResp2 = await planning.call('satisfaction', 'create_satisfaction', { satisfaction: satisfaction2 })
+  const satisfactionResp2 = await alice.call('planning', 'satisfaction', 'create_satisfaction', { satisfaction: satisfaction2 })
   t.ok(satisfactionResp2.Ok.satisfaction && satisfactionResp2.Ok.satisfaction.id, 'satisfaction by commitment created successfully')
-  await s.consistent()
+  await s.consistency()
   const satisfactionId2 = satisfactionResp2.Ok.satisfaction.id
 
   // ASSERT: check commitment field refs
-  readResponse = await planning.call('commitment', 'get_commitment', { address: commitmentId })
+  readResponse = await alice.call('planning', 'commitment', 'get_commitment', { address: commitmentId })
   t.ok(readResponse.Ok.commitment.satisfies, 'Commitment.satisfies value present')
   t.equal(readResponse.Ok.commitment.satisfies.length, 1, 'Commitment.satisfies reference saved')
   t.equal(readResponse.Ok.commitment.satisfies[0], satisfactionId2, 'Commitment.satisfies reference OK')
 
   // ASSERT: check intent query indices
-  readResponse = await planning.call('satisfaction', 'query_satisfactions', { params: { satisfies: intentId } })
+  readResponse = await alice.call('planning', 'satisfaction', 'query_satisfactions', { params: { satisfies: intentId } })
   t.equal(readResponse.Ok.length, 2, 'appending satisfactions for read OK')
   t.equal(readResponse.Ok[0].satisfaction.id, satisfactionId, 'satisfaction 1 indexed correctly')
   t.equal(readResponse.Ok[1].satisfaction.id, satisfactionId2, 'satisfaction 2 indexed correctly')
 
   // ASSERT: check intent field refs
-  readResponse = await planning.call('intent', 'get_intent', { address: intentId })
+  readResponse = await alice.call('planning', 'intent', 'get_intent', { address: intentId })
   t.equal(readResponse.Ok.intent.satisfiedBy.length, 2, 'Intent.satisfiedBy appending OK')
   t.equal(readResponse.Ok.intent.satisfiedBy[0], satisfactionId, 'Intent.satisfiedBy reference 1 OK')
   t.equal(readResponse.Ok.intent.satisfiedBy[1], satisfactionId2, 'Intent.satisfiedBy reference 2 OK')
 
   // ASSERT: check commitment query indexes
-  readResponse = await planning.call('satisfaction', 'query_satisfactions', { params: { satisfiedBy: commitmentId } })
+  readResponse = await alice.call('planning', 'satisfaction', 'query_satisfactions', { params: { satisfiedBy: commitmentId } })
   t.equal(readResponse.Ok.length, 1, 'read satisfactions by commitment OK')
   t.equal(readResponse.Ok[0].satisfaction.id, satisfactionId2, 'Satisfaction.satisfiedBy indexed correctly')
 
   // ASSERT: check intent satisfaction query indexes
-  readResponse = await planning.call('intent', 'query_intents', { params: { satisfiedBy: satisfactionId2 } })
+  readResponse = await alice.call('planning', 'intent', 'query_intents', { params: { satisfiedBy: satisfactionId2 } })
   t.equal(readResponse.Ok.length, 1, 'appending satisfactions for intent query OK')
   t.equal(readResponse.Ok[0].intent.id, intentId, 'intent query 2 indexed correctly')
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,6 +1075,13 @@
     isomorphic-fetch "^2.2.1"
     rpc-websockets "^4.3.3"
 
+"@holochain/hcid-js@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@holochain/hcid-js/-/hcid-js-0.0.5.tgz#8dbcc08172eb1f5c7cd3e14aaad9876c8047f2ca"
+  integrity sha512-55ehnALVASaQTIHdLSbCFYKIBHiSElhj5U4KfiqpCwNPuyQCBgWK/1D9JW254ci626IUcPvJDo7Wljmgb9fwwQ==
+  dependencies:
+    text-encoding "^0.7.0"
+
 "@holochain/try-o-rama@0.1.2-beta.4":
   version "0.1.2-beta.4"
   resolved "https://registry.yarnpkg.com/@holochain/try-o-rama/-/try-o-rama-0.1.2-beta.4.tgz#d2ec9696741c0b94fad435909678d8c2e7fd2b7a"
@@ -2383,6 +2390,13 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base-x@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.7.tgz#1c5a7fafe8f66b4114063e8da102799d4e7c408f"
+  integrity sha512-zAKJGuQPihXW22fkrfOclUUZXM2g92z5GzlSMHxhO6r6Qj+Nm0ccaGNBzDZojzwOMkpjAv4J0fOv1U4go+a4iw==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 base64-js@^1.0.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
@@ -2413,6 +2427,14 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+better-sqlite3@^5.4.0:
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-5.4.3.tgz#2cb843ce14c56de9e9c0ca6b89844b7d4b5794b8"
+  integrity sha512-fPp+8f363qQIhuhLyjI4bu657J/FfMtgiiHKfaTsj3RWDkHlWC1yT7c6kHZDnBxzQVoAINuzg553qKmZ4F1rEw==
+  dependencies:
+    integer "^2.1.0"
+    tar "^4.4.10"
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -2427,6 +2449,17 @@ binary-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
+
+bip39@^2.5.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/bip39/-/bip39-2.6.0.tgz#9e3a720b42ec8b3fbe4038f1e445317b6a99321c"
+  integrity sha512-RrnQRG2EgEoqO24ea+Q/fftuPUZLmrEM3qNhhGsA3PbaXaCW791LTzPuVyx/VprXQcTbPJ3K3UeTna8ZnVl2sg==
+  dependencies:
+    create-hash "^1.1.0"
+    pbkdf2 "^3.0.9"
+    randombytes "^2.0.1"
+    safe-buffer "^5.0.1"
+    unorm "^1.3.3"
 
 bluebird@^3.5.3:
   version "3.5.4"
@@ -2470,6 +2503,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
+bowser@^2.6.1:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.7.0.tgz#96eab1fa07fab08c1ec4c75977a7c8ddf8e0fe1f"
+  integrity sha512-aIlMvstvu8x+34KEiOHD3AsBgdrzg6sxALYiukOWhFvGMbQI6TRP/iY0LMhUrHs56aD6P1G0Z7h45PUJaa5m9w==
 
 boxen@^1.2.1:
   version "1.3.0"
@@ -2609,6 +2647,13 @@ browserslist@^4.0.0, browserslist@^4.1.1, browserslist@^4.4.2, browserslist@^4.5
     electron-to-chromium "^1.3.133"
     node-releases "^1.1.19"
 
+bs58@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
+  integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
+  dependencies:
+    base-x "^3.0.2"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -2741,6 +2786,11 @@ camelcase@^5.0.0, camelcase@^5.2.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
+camelize@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
+  integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-api@^3.0.0:
   version "3.0.0"
@@ -3250,6 +3300,11 @@ content-disposition@0.5.3:
   dependencies:
     safe-buffer "5.1.2"
 
+content-security-policy-builder@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/content-security-policy-builder/-/content-security-policy-builder-2.1.0.tgz#0a2364d769a3d7014eec79ff7699804deb8cfcbb"
+  integrity sha512-/MtLWhJVvJNkA9dVLAp6fg9LxD2gfI6R2Fi1hPmfjYXSahJJzcfvoeDOxSyp4NvxMuwWv3WMssE9o31DoULHrQ==
+
 content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
@@ -3671,6 +3726,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+dasherize@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dasherize/-/dasherize-2.0.0.tgz#6d809c9cd0cf7bb8952d80fc84fa13d47ddb1308"
+  integrity sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg=
+
 data-urls@^1.0.0, data-urls@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
@@ -3846,6 +3906,11 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+depd@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -3951,6 +4016,19 @@ dns-packet@^1.3.1:
     ip "^1.1.0"
     safe-buffer "^5.0.1"
 
+dns-packet@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-4.2.0.tgz#3fd6f5ff5a4ec3194ed0b15312693ffe8776b343"
+  integrity sha512-bn1AKpfkFbm0MIioOMHZ5qJzl2uypdBwI4nYNsqvhjsegBhcKJUlCrMPWLx6JEezRjxZmxhtIz/FkBEur2l8Cw==
+  dependencies:
+    ip "^1.1.5"
+    safe-buffer "^5.1.1"
+
+dns-prefetch-control@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/dns-prefetch-control/-/dns-prefetch-control-0.2.0.tgz#73988161841f3dcc81f47686d539a2c702c88624"
+  integrity sha512-hvSnros73+qyZXhHFjx2CMLwoj3Fe7eR9EJsFsqmcI1bB2OBWL/+0YzaEaKssCHnj/6crawNnUyw74Gm2EKe+Q==
+
 dns-txt@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/dns-txt/-/dns-txt-2.0.2.tgz#b91d806f5d27188e4ab3e7d107d881a1cc4642b6"
@@ -4047,6 +4125,11 @@ domutils@^1.5.1, domutils@^1.7.0:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+dont-sniff-mimetype@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/dont-sniff-mimetype/-/dont-sniff-mimetype-1.1.0.tgz#c7d0427f8bcb095762751252af59d148b0a623b2"
+  integrity sha512-ZjI4zqTaxveH2/tTlzS1wFp+7ncxNZaIEWYg3lzZRHkKf5zPT/MnEG6WL0BhHMJUabkh8GeU5NL5j+rEUCb7Ug==
 
 dot-case@^2.1.0:
   version "2.1.1"
@@ -4531,6 +4614,11 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
+event-lite@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/event-lite/-/event-lite-0.1.2.tgz#838a3e0fdddef8cc90f128006c8e55a4e4e4c11b"
+  integrity sha512-HnSYx1BsJ87/p6swwzv+2v6B4X+uxUteoDfRxsAb1S1BePzQqOLevVmkdA15GHJVd9A9Ok6wygUR18Hu0YeV9g==
+
 eventemitter3@^3.0.0, eventemitter3@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
@@ -4605,6 +4693,11 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+expect-ct@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/expect-ct/-/expect-ct-0.2.0.tgz#3a54741b6ed34cc7a93305c605f63cd268a54a62"
+  integrity sha512-6SK3MG/Bbhm8MsgyJAylg+ucIOU71/FzyFalcfu5nY19dH8y/z0tBJU0wrNBXD4B27EoQtqPF/9wqH0iYAd04g==
+
 expect@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-24.8.0.tgz#471f8ec256b7b6129ca2524b2a62f030df38718d"
@@ -4617,10 +4710,53 @@ expect@^24.8.0:
     jest-message-util "^24.8.0"
     jest-regex-util "^24.3.0"
 
+express-ws@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/express-ws/-/express-ws-4.0.0.tgz#dabd8dc974516418902a41fe6e30ed949b4d36c4"
+  integrity sha512-KEyUw8AwRET2iFjFsI1EJQrJ/fHeGiJtgpYgEWG3yDv4l/To/m3a2GaYfeGyB3lsWdvbesjF5XCMx+SVBgAAYw==
+  dependencies:
+    ws "^5.2.0"
+
 express@^4.16.2:
   version "4.17.0"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.0.tgz#288af62228a73f4c8ea2990ba3b791bb87cd4438"
   integrity sha512-1Z7/t3Z5ZnBG252gKUPyItc4xdeaA0X934ca2ewckAsVsw9EG71i++ZHZPYnus8g/s5Bty8IMpSVEuRkmwwPRQ==
+  dependencies:
+    accepts "~1.3.7"
+    array-flatten "1.1.1"
+    body-parser "1.19.0"
+    content-disposition "0.5.3"
+    content-type "~1.0.4"
+    cookie "0.4.0"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "~1.1.2"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "~1.1.2"
+    fresh "0.5.2"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "~2.3.0"
+    parseurl "~1.3.3"
+    path-to-regexp "0.1.7"
+    proxy-addr "~2.0.5"
+    qs "6.7.0"
+    range-parser "~1.2.1"
+    safe-buffer "5.1.2"
+    send "0.17.1"
+    serve-static "1.14.1"
+    setprototypeof "1.1.1"
+    statuses "~1.5.0"
+    type-is "~1.6.18"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
+
+express@^4.16.4:
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
+  integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
   dependencies:
     accepts "~1.3.7"
     array-flatten "1.1.1"
@@ -4771,6 +4907,11 @@ fb-watchman@^2.0.0:
   integrity sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=
   dependencies:
     bser "^2.0.0"
+
+feature-policy@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/feature-policy/-/feature-policy-0.3.0.tgz#7430e8e54a40da01156ca30aaec1a381ce536069"
+  integrity sha512-ZtijOTFN7TzCujt1fnNhfWPFPSHeZkesff9AXZj+UEjYBynWNUIYpC87Ve4wHzyexQsImicLu7WsC2LHq7/xrQ==
 
 fecha@^2.3.3:
   version "2.3.3"
@@ -5008,6 +5149,11 @@ fragment-cache@^0.2.1:
   integrity sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
   dependencies:
     map-cache "^0.2.2"
+
+frameguard@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/frameguard/-/frameguard-3.1.0.tgz#bd1442cca1d67dc346a6751559b6d04502103a22"
+  integrity sha512-TxgSKM+7LTA6sidjOiSZK9wxY0ffMPY3Wta//MqwmX0nZuEHc8QrkV8Fh3ZhMJeiH+Uyh/tcaarImRy8u77O7g==
 
 fresh@0.5.2:
   version "0.5.2"
@@ -5616,10 +5762,51 @@ header-case@^1.0.0:
     no-case "^2.2.0"
     upper-case "^1.1.3"
 
+helmet-crossdomain@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/helmet-crossdomain/-/helmet-crossdomain-0.4.0.tgz#5f1fe5a836d0325f1da0a78eaa5fd8429078894e"
+  integrity sha512-AB4DTykRw3HCOxovD1nPR16hllrVImeFp5VBV9/twj66lJ2nU75DP8FPL0/Jp4jj79JhTfG+pFI2MD02kWJ+fA==
+
+helmet-csp@2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/helmet-csp/-/helmet-csp-2.9.2.tgz#bec0adaf370b0f2e77267c9d8b6e33b34159c1e5"
+  integrity sha512-Lt5WqNfbNjEJ6ysD4UNpVktSyjEKfU9LVJ1LaFmPfYseg/xPealPfgHhtqdAdjPDopp5zbg/VWCyp4cluMIckw==
+  dependencies:
+    bowser "^2.6.1"
+    camelize "1.0.0"
+    content-security-policy-builder "2.1.0"
+    dasherize "2.0.0"
+
+helmet@^3.15.0:
+  version "3.21.1"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-3.21.1.tgz#b0ab7c63fc30df2434be27e7e292a9523b3147e9"
+  integrity sha512-IC/54Lxvvad2YiUdgLmPlNFKLhNuG++waTF5KPYq/Feo3NNhqMFbcLAlbVkai+9q0+4uxjxGPJ9bNykG+3zZNg==
+  dependencies:
+    depd "2.0.0"
+    dns-prefetch-control "0.2.0"
+    dont-sniff-mimetype "1.1.0"
+    expect-ct "0.2.0"
+    feature-policy "0.3.0"
+    frameguard "3.1.0"
+    helmet-crossdomain "0.4.0"
+    helmet-csp "2.9.2"
+    hide-powered-by "1.1.0"
+    hpkp "2.0.0"
+    hsts "2.2.0"
+    ienoopen "1.1.0"
+    nocache "2.1.0"
+    referrer-policy "1.2.0"
+    x-xss-protection "1.3.0"
+
 hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
+
+hide-powered-by@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/hide-powered-by/-/hide-powered-by-1.1.0.tgz#be3ea9cab4bdb16f8744be873755ca663383fa7a"
+  integrity sha512-Io1zA2yOA1YJslkr+AJlWSf2yWFkKjvkcL9Ni1XSUqnGLr/qRQe2UI3Cn/J9MsJht7yEVCe0SscY1HgVMujbgg==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -5645,6 +5832,11 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
+hpkp@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/hpkp/-/hpkp-2.0.0.tgz#10e142264e76215a5d30c44ec43de64dee6d1672"
+  integrity sha1-EOFCJk52IVpdMMROxD3mTe5tFnI=
+
 hsl-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hsl-regex/-/hsl-regex-1.0.0.tgz#d49330c789ed819e276a4c0d272dffa30b18fe6e"
@@ -5654,6 +5846,13 @@ hsla-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
+
+hsts@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/hsts/-/hsts-2.2.0.tgz#09119d42f7a8587035d027dda4522366fe75d964"
+  integrity sha512-ToaTnQ2TbJkochoVcdXYm4HOCliNozlviNsg+X2XQLQvZNI/kCHR9rZxVYpJB3UPcHz80PgxRyWQ7PdU1r+VBQ==
+  dependencies:
+    depd "2.0.0"
 
 html-comment-regex@^1.1.0:
   version "1.1.2"
@@ -5799,10 +5998,15 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ieee754@^1.1.4:
+ieee754@^1.1.4, ieee754@^1.1.8:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
+ienoopen@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ienoopen/-/ienoopen-1.1.0.tgz#411e5d530c982287dbdc3bb31e7a9c9e32630974"
+  integrity sha512-MFs36e/ca6ohEKtinTJ5VvAJ6oDRAYFdYXweUnGY9L9vcoqFOU4n2ZhmJ0C4z/cwGZ3YIQRSB3XZ1+ghZkY5NQ==
 
 iferr@^0.1.5:
   version "0.1.5"
@@ -5976,6 +6180,16 @@ inquirer@6.3.1, inquirer@^6.2.2:
     string-width "^2.1.0"
     strip-ansi "^5.1.0"
     through "^2.3.6"
+
+int64-buffer@^0.1.9:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.1.10.tgz#277b228a87d95ad777d07c13832022406a473423"
+  integrity sha1-J3siiofZWtd30HwTgyAiQGpHNCM=
+
+integer@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/integer/-/integer-2.1.0.tgz#29134ea2f7ba3362ed4dbe6bcca992b1f18ff276"
+  integrity sha512-vBtiSgrEiNocWvvZX1RVfeOKa2mCHLZQ2p9nkQkQZ/BvEiY+6CcUz0eyjvIiewjJoeNidzg2I+tpPJvpyspL1w==
 
 internal-ip@^4.2.0:
   version "4.3.0"
@@ -7713,12 +7927,27 @@ minipass@^2.2.1, minipass@^2.3.4:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
+minipass@^2.8.6, minipass@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
+  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
 minizlib@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
   integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
   dependencies:
     minipass "^2.2.1"
+
+minizlib@^1.2.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
+  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
+  dependencies:
+    minipass "^2.9.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -7781,6 +8010,16 @@ ms@2.1.1, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
+msgpack-lite@^0.1.26:
+  version "0.1.26"
+  resolved "https://registry.yarnpkg.com/msgpack-lite/-/msgpack-lite-0.1.26.tgz#dd3c50b26f059f25e7edee3644418358e2a9ad89"
+  integrity sha1-3TxQsm8FnyXn7e42REGDWOKprYk=
+  dependencies:
+    event-lite "^0.1.1"
+    ieee754 "^1.1.8"
+    int64-buffer "^0.1.9"
+    isarray "^1.0.0"
+
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
@@ -7794,12 +8033,36 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
+"multicast-dns@github:holochain/multicast-dns":
+  version "7.2.0"
+  resolved "https://codeload.github.com/holochain/multicast-dns/tar.gz/05fbb6fe0e3902980d3a84f9c32c9d1b1d02f1b1"
+  dependencies:
+    dns-packet "^4.0.0"
+    thunky "^1.0.2"
+
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-nan@^2.12.1:
+"n3h@github:holochain/n3h#0.0.20-alpha":
+  version "0.0.20-alpha"
+  resolved "https://codeload.github.com/holochain/n3h/tar.gz/8cabb42987a2b87e2c401de2aa8e756fe400cf51"
+  dependencies:
+    "@holochain/hcid-js" "^0.0.5"
+    better-sqlite3 "^5.4.0"
+    bip39 "^2.5.0"
+    bs58 "^4.0.1"
+    express "^4.16.4"
+    express-ws "^4.0.0"
+    helmet "^3.15.0"
+    msgpack-lite "^0.1.26"
+    multicast-dns "github:holochain/multicast-dns"
+    node-forge "^0.7.6"
+    sodium-native "2.3.0"
+    ws "^6.1.2"
+
+nan@^2.12.1, nan@^2.4.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
@@ -7862,6 +8125,11 @@ no-case@^2.2.0, no-case@^2.3.2:
   dependencies:
     lower-case "^1.1.1"
 
+nocache@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/nocache/-/nocache-2.1.0.tgz#120c9ffec43b5729b1d5de88cd71aa75a0ba491f"
+  integrity sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q==
+
 node-fetch@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
@@ -7884,6 +8152,16 @@ node-forge@0.7.5:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"
   integrity sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==
+
+node-forge@^0.7.6:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
+  integrity sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==
+
+node-gyp-build@^3.0.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-3.9.0.tgz#53a350187dd4d5276750da21605d1cb681d09e25"
+  integrity sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -8561,7 +8839,7 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
-pbkdf2@^3.0.3:
+pbkdf2@^3.0.3, pbkdf2@^3.0.9:
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
   integrity sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==
@@ -9806,6 +10084,11 @@ recursive-readdir@2.2.2:
   dependencies:
     minimatch "3.0.4"
 
+referrer-policy@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/referrer-policy/-/referrer-policy-1.2.0.tgz#b99cfb8b57090dc454895ef897a4cc35ef67a98e"
+  integrity sha512-LgQJIuS6nAy1Jd88DCQRemyE3mS+ispwlqMk3b0yjZ257fI1v9c+/p6SD5gP5FGyXUIgrNOAfmyioHwZtYv2VA==
+
 regenerate-unicode-properties@^8.0.2:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz#ef51e0f0ea4ad424b77bf7cb41f3e015c70a3f0e"
@@ -10526,6 +10809,15 @@ sockjs@0.3.19:
     faye-websocket "^0.10.0"
     uuid "^3.0.1"
 
+sodium-native@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/sodium-native/-/sodium-native-2.3.0.tgz#40cee5f504bb5f6196cc40c42748162d66ec2598"
+  integrity sha512-TYId1m2iLXXot2Q3KA6u8Ti9pmL24T2cm8nb9OUGFFmTxdw4I+vnkjcPVA4LT1acw+A86iJkEn+8iV51jcTWUg==
+  dependencies:
+    ini "^1.3.5"
+    nan "^2.4.0"
+    node-gyp-build "^3.0.0"
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
@@ -11022,6 +11314,19 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
+tar@^4.4.10:
+  version "4.4.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
+  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.8.6"
+    minizlib "^1.2.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.3"
+
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
@@ -11076,6 +11381,11 @@ test-exclude@^5.2.3:
     minimatch "^3.0.4"
     read-pkg-up "^4.0.0"
     require-main-filename "^2.0.0"
+
+text-encoding@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.7.0.tgz#f895e836e45990624086601798ea98e8f36ee643"
+  integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
 
 text-hex@1.0.x:
   version "1.0.0"
@@ -11509,6 +11819,11 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+unorm@^1.3.3:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/unorm/-/unorm-1.6.0.tgz#029b289661fba714f1a9af439eb51d9b16c205af"
+  integrity sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
@@ -12245,6 +12560,11 @@ x-is-string@^0.1.0:
   resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
   integrity sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=
 
+x-xss-protection@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/x-xss-protection/-/x-xss-protection-1.3.0.tgz#3e3a8dd638da80421b0e9fff11a2dbe168f6d52c"
+  integrity sha512-kpyBI9TlVipZO4diReZMAHWtS0MMa/7Kgx8hwG/EuZLiA6sg4Ah/4TRdASHhRRN3boobzcYgFRUFSgHRge6Qhg==
+
 xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
@@ -12291,6 +12611,11 @@ yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+
+yallist@^3.0.3:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yargs-parser@^10.1.0:
   version "10.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1057,27 +1057,13 @@
   dependencies:
     "@hapi/hoek" "6.x.x"
 
-"@holochain/diorama@0.2.0-rc.1":
-  version "0.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@holochain/diorama/-/diorama-0.2.0-rc.1.tgz#5575a1441fe33a6be73fc13abc555c63ef8c1eda"
-  integrity sha512-3NQlhMBeweKk6eoeeKlrs/5XZ+UyERKCIlol+5AwTxlVyMxnGb785wsby2Mcj8BJL0IHz0KfnNfOeqBv97675w==
-  dependencies:
-    "@holochain/hachiko" "^0.2.0-rc.1"
-    "@holochain/hc-web-client" "^0.5.0"
-    colors "^1.3.3"
-    del "^4.1.1"
-    get-port "^5.0.0"
-    lodash "^4.17.11"
-    winston "^3.2.1"
-    winston-null "^2.0.0"
-
-"@holochain/hachiko@^0.2.0-rc.1":
-  version "0.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@holochain/hachiko/-/hachiko-0.2.0-rc.1.tgz#2c1d7e1871f4cc528f82969453cbe4f43458d31e"
-  integrity sha512-lAvVpna/SATlj9L605DItTLGV2m+QhbGREvPX3P39eEbHak8eMzMydT01BNV5LC6HkafgoKVYpq0mrHOe5QTDg==
+"@holochain/hachiko@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@holochain/hachiko/-/hachiko-0.4.1.tgz#47aab3a8561e3a9bb97664cb8a22f8937e347ce3"
+  integrity sha512-IEkdz7I7tjRwYuGW1+Q8yqvawR70xfu9W9dWVxNDOhvqByoHgMGL90BxF3H1HbVOxlaPYuLbHogp8sRttserQg==
   dependencies:
     colors "^1.3.3"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     winston "^3.2.1"
     winston-null "^2.0.0"
 
@@ -1088,6 +1074,30 @@
   dependencies:
     isomorphic-fetch "^2.2.1"
     rpc-websockets "^4.3.3"
+
+"@holochain/try-o-rama@0.1.2-beta.4":
+  version "0.1.2-beta.4"
+  resolved "https://registry.yarnpkg.com/@holochain/try-o-rama/-/try-o-rama-0.1.2-beta.4.tgz#d2ec9696741c0b94fad435909678d8c2e7fd2b7a"
+  integrity sha512-uxzS3UZAzmgxpSpDQgVArbFsO43pnskHaeFrCp1vg4TQFO0ZlbZ5yZgz8do21QENtsrP/X9+N1/vk21pdy69xg==
+  dependencies:
+    "@holochain/hachiko" "^0.4.1"
+    "@holochain/hc-web-client" "^0.5.0"
+    "@iarna/toml" "^2.2.3"
+    async-mutex "^0.1.4"
+    axios "^0.19.0"
+    colors "^1.3.3"
+    fp-ts "^2.0.5"
+    get-port "^5.0.0"
+    io-ts "^2.0.1"
+    io-ts-reporters "^1.0.0"
+    lodash "^4.17.15"
+    uuid "^3.3.3"
+    winston "^3.2.1"
+
+"@iarna/toml@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.3.tgz#f060bf6eaafae4d56a7dac618980838b0696e2ab"
+  integrity sha512-FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==
 
 "@jest/console@^24.7.1":
   version "24.7.1"
@@ -1234,6 +1244,17 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
+
+"@kamilkisiela/graphql-tools@4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@kamilkisiela/graphql-tools/-/graphql-tools-4.0.6.tgz#6dcf4d18bedaf34f6ab1d5bad2414e530d0875d1"
+  integrity sha512-IPWa+dOFCE4zaCsrJrAMp7yWXnfOZLNhqoMEOmn958WkLM0mmsDc/W/Rh7/7xopIT6P0oizb6/N1iH5HnNXOUA==
+  dependencies:
+    apollo-link "^1.2.3"
+    apollo-utilities "^1.0.1"
+    deprecated-decorator "^0.1.6"
+    iterall "^1.1.3"
+    uuid "^3.1.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -1410,7 +1431,7 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/glob@^7.1.1":
+"@types/glob@7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
   integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
@@ -1797,6 +1818,14 @@ aggregate-error@2.2.0:
     clean-stack "^2.0.0"
     indent-string "^3.0.0"
 
+aggregate-error@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.0.tgz#5b5a3c95e9095f311c9ab16c19fb4f3527cd3f79"
+  integrity sha512-yKD9kEoJIR+2IFqhMwayIBgheLYbB3PS2OBhWae1L/ODTd/JF/30cW0bc9TqzRL3k4U41Dieu3BF4I29p8xesA==
+  dependencies:
+    clean-stack "^2.0.0"
+    indent-string "^3.2.0"
+
 ajv-errors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
@@ -2098,6 +2127,11 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
   integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
 
+async-mutex@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.1.4.tgz#a47d1eebf584f7dcdd760e3642dc2c58613bef5c"
+  integrity sha512-zVWTmAnxxHaeB2B1te84oecI8zTDJ/8G49aVBblRX6be0oq6pAybNcUSxwfgVOmOjSCvN4aYZAqwtyNI8e1YGw==
+
 async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -2158,6 +2192,14 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
+axios@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
+  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
 
 axobject-query@^2.0.2:
   version "2.0.2"
@@ -2762,6 +2804,11 @@ chalk@^1.0.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chance@^1.0.16:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chance/-/chance-1.1.3.tgz#414f08634ee479c7a316b569050ea20751b82dd3"
+  integrity sha512-XeJsdoVAzDb1WRPRuMBesRSiWpW1uNTo5Fd7mYxPJsAfgX71+jfuCOHOdbyBz2uAUZ8TwKcXgWk3DMedFfJkbg==
+
 change-case@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/change-case/-/change-case-3.1.0.tgz#0e611b7edc9952df2e8513b27b42de72647dd17e"
@@ -3337,6 +3384,14 @@ cross-fetch@2.2.2:
     node-fetch "2.1.2"
     whatwg-fetch "2.0.4"
 
+cross-fetch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.4.tgz#7bef7020207e684a7638ef5f2f698e24d9eb283c"
+  integrity sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==
+  dependencies:
+    node-fetch "2.6.0"
+    whatwg-fetch "3.0.0"
+
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -3647,6 +3702,13 @@ debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^3.1.0, debug@^3.2.5, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -3710,6 +3772,11 @@ deepmerge@3.2.0:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.2.0.tgz#58ef463a57c08d376547f8869fdc5bcee957f44e"
   integrity sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==
 
+deepmerge@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.0.0.tgz#3e3110ca29205f120d7cb064960a39c3d2087c09"
+  integrity sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww==
+
 default-gateway@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-4.2.0.tgz#167104c7500c2115f6dd69b0a536bb8ed720552b"
@@ -3768,19 +3835,6 @@ del@^3.0.0:
     p-map "^1.1.1"
     pify "^3.0.0"
     rimraf "^2.2.8"
-
-del@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/del/-/del-4.1.1.tgz#9e8f117222ea44a31ff3a156c049b99052a9f0b4"
-  integrity sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==
-  dependencies:
-    "@types/glob" "^7.1.1"
-    globby "^6.1.0"
-    is-path-cwd "^2.0.0"
-    is-path-in-cwd "^2.0.0"
-    p-map "^2.0.0"
-    pify "^4.0.1"
-    rimraf "^2.6.3"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -4037,6 +4091,35 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
+
+easygraphql-mock@^0.1.15:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/easygraphql-mock/-/easygraphql-mock-0.1.15.tgz#7cd992842beab38d73dd1ce1fd2c1164ecdfcd87"
+  integrity sha512-TQMpAuf9Uep8sCCb3NIxJGebM5Do1FkJ4nCNr4H8bYdu0dMkcj34/vRU6CzQ0fOv1f8Z/ThGWQQHZTcB2IVbKQ==
+  dependencies:
+    chance "^1.0.16"
+    easygraphql-parser "^0.0.12"
+
+easygraphql-parser@^0.0.12:
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/easygraphql-parser/-/easygraphql-parser-0.0.12.tgz#be97d9119abcebd4458194308a8e08a2324c6e38"
+  integrity sha512-lawcyfGQHY0DkDlHYCMhUOoe/O6q2gdzVLcHIXerkoAcz3ScMjLdxInO76JRuEpWc/TerPZ+HaHs18+4c79V1w==
+  dependencies:
+    graphql "^14.4.0"
+    merge-graphql-schemas "^1.5.8"
+
+easygraphql-tester@5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/easygraphql-tester/-/easygraphql-tester-5.1.6.tgz#a4e99585c4e857332b2291940f6a10e8a483f09c"
+  integrity sha512-f2u8z9sgjfyZ2QGaie05oWUAYSyW2u1dq0IZImGXnD/Z20bKrJjbdI7q1Q+S51gIwP6EJGHwCTDGkPI6ClN2jQ==
+  dependencies:
+    easygraphql-mock "^0.1.15"
+    easygraphql-parser "^0.0.12"
+    graphql "^14.4.0"
+    graphql-tools "^4.0.4"
+    lodash.isempty "^4.4.0"
+    lodash.isobject "^3.0.2"
+    merge-graphql-schemas "^1.5.8"
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -4836,6 +4919,13 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
+
 follow-redirects@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
@@ -4906,6 +4996,11 @@ forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
+
+fp-ts@^2.0.2, fp-ts@^2.0.5:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.1.0.tgz#dac1b13ade6d52deb823bee53e99e3a804cc6e05"
+  integrity sha512-2xTHhLuP0uLjpaHAARpGQ1TpIPqEUMu8fGN5jv8py0T+HgB6a4bV57p5EQoOyeHws4SuYxiUi2/m0isHs6F/cA==
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -5027,7 +5122,7 @@ get-own-enumerable-property-symbols@^3.0.0:
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz#b877b49a5c16aefac3655f2ed2ea5b684df8d203"
   integrity sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==
 
-get-port@^5.0.0:
+get-port@5.0.0, get-port@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.0.0.tgz#aa22b6b86fd926dd7884de3e23332c9f70c031a6"
   integrity sha512-imzMU0FjsZqNa6BqOjbbW6w5BivHIuQKopjpPqcnx0AVHJQKCxK1O+Ab3OrVXhrekqfVMjwA9ZYu062R+KcIsQ==
@@ -5315,6 +5410,25 @@ graphql-toolkit@0.2.12:
     tslib "^1.9.3"
     valid-url "1.0.9"
 
+graphql-toolkit@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/graphql-toolkit/-/graphql-toolkit-0.5.0.tgz#7371c21809898286b2a9e164b45469586cf64498"
+  integrity sha512-tBgqyWPHI/Pgt+jp+uLZZy2EBCzjd6yWAu73oUlmrhgg7XM6f1ONotVHvIO2MK7j8khR+ex/cUe8FgpS1i845w==
+  dependencies:
+    "@kamilkisiela/graphql-tools" "4.0.6"
+    "@types/glob" "7.1.1"
+    aggregate-error "3.0.0"
+    asyncro "^3.0.0"
+    cross-fetch "^3.0.4"
+    deepmerge "4.0.0"
+    glob "7.1.4"
+    graphql-import "0.7.1"
+    is-glob "4.0.1"
+    is-valid-path "0.1.1"
+    lodash "4.17.15"
+    tslib "^1.9.3"
+    valid-url "1.0.9"
+
 graphql-tools@4.0.4, graphql-tools@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.4.tgz#ca08a63454221fdde825fe45fbd315eb2a6d566b"
@@ -5325,6 +5439,13 @@ graphql-tools@4.0.4, graphql-tools@^4.0.4:
     deprecated-decorator "^0.1.6"
     iterall "^1.1.3"
     uuid "^3.1.0"
+
+graphql@14.5.8, graphql@^14.4.0:
+  version "14.5.8"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.5.8.tgz#504f3d3114cb9a0a3f359bbbcf38d9e5bf6a6b3c"
+  integrity sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==
+  dependencies:
+    iterall "^1.2.2"
 
 graphql@^14.3.0:
   version "14.3.0"
@@ -5780,7 +5901,7 @@ indent-string@4.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
-indent-string@^3.0.0:
+indent-string@^3.0.0, indent-string@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
   integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
@@ -5876,6 +5997,19 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
+io-ts-reporters@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/io-ts-reporters/-/io-ts-reporters-1.0.0.tgz#c5901d49d454956698bbca48b328698f8ca1c9c7"
+  integrity sha512-jjMvTnFYYxX3ue3cajmqCAf7sM4+lFvaaUuAL+otJv2DE+WDxYvQeCcUYveoq37rVSftJHZBEOrnvz3x0VdRXA==
+  dependencies:
+    fp-ts "^2.0.2"
+    io-ts "^2.0.0"
+
+io-ts@^2.0.0, io-ts@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.0.1.tgz#1261c12f915c2f48d16393a36966636b48a45aa1"
+  integrity sha512-RezD+WcCfW4VkMkEcQWL/Nmy/nqsWTvTYg7oUmTGzglvSSV2P9h2z1PVeREPFf0GWNzruYleAt1XCMQZSg1xxQ==
+
 ip-regex@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
@@ -5943,6 +6077,11 @@ is-buffer@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
   integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
+
+is-buffer@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
+  integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
 is-callable@^1.1.3, is-callable@^1.1.4:
   version "1.1.4"
@@ -6150,11 +6289,6 @@ is-path-cwd@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
   integrity sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=
 
-is-path-cwd@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.1.0.tgz#2e0c7e463ff5b7a0eb60852d851a6809347a124c"
-  integrity sha512-Sc5j3/YnM8tDeyCsVeKlm/0p95075DyLmDEIkSgQ7mXkrOX+uTCtmQFm0CYzVyJwcCCmO3k8qfJt17SxQwB5Zw==
-
 is-path-in-cwd@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
@@ -6162,26 +6296,12 @@ is-path-in-cwd@^1.0.0:
   dependencies:
     is-path-inside "^1.0.0"
 
-is-path-in-cwd@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz#bfe2dca26c69f397265a4009963602935a053acb"
-  integrity sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==
-  dependencies:
-    is-path-inside "^2.1.0"
-
 is-path-inside@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
   integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
   dependencies:
     path-is-inside "^1.0.1"
-
-is-path-inside@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-2.1.0.tgz#7c9810587d659a40d27bcdb4d5616eab059494b2"
-  integrity sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==
-  dependencies:
-    path-is-inside "^1.0.2"
 
 is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -7168,6 +7288,16 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.isempty@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
+  integrity sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=
+
+lodash.isobject@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
+  integrity sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -7212,6 +7342,11 @@ lodash@4.17.11, "lodash@>=3.5 <5", lodash@^4.17.10, lodash@^4.17.11, lodash@^4.1
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+lodash@4.17.15, lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-symbols@3.0.0:
   version "3.0.0"
@@ -7427,6 +7562,14 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
+
+merge-graphql-schemas@^1.5.8:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/merge-graphql-schemas/-/merge-graphql-schemas-1.7.0.tgz#bedf99b90096d4b324f8e81271e878e6b5cc930d"
+  integrity sha512-uxErpYVjlf91eTBdwHxVEwKtaosmmEHMJaQfe35XHwOEpUfhA9OFbYKRfZX5jUUS53xMnk203HDAl/u0EfjP7A==
+  dependencies:
+    graphql-toolkit "0.5.0"
+    tslib "1.10.0"
 
 merge-stream@^1.0.1:
   version "1.0.1"
@@ -7723,6 +7866,11 @@ node-fetch@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
+
+node-fetch@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -11513,6 +11661,11 @@ uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+uuid@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
+  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
 valid-url@1.0.9:
   version "1.0.9"


### PR DESCRIPTION
Implements #44 and upgrades the testing framework to the new [try-o-rama](https://github.com/holochain/try-o-rama).

@JhonatanHern @fosterlynn @bhaugen see `tests/flows/flow_records_graphql.js` for an example of what an end-to-end GraphQL integration test looks like. We should move to authoring all tests against the GraphQL API moving forward to ensure the clientside aspects of the work are not forgotten. Also provides useful code for UI app developers as a side-effect. 

I'm also noticing that the RPC layer still shifts from time to time, like it did in this latest Holochain upgrade- so testing against GraphQL can protect us from this churn.

Going to go ahead and merge now, so the pattern is established and we can avoid needing to migrate more tests later. **After pulling these changes, you will need exit and re-open your `nix-shell`, then re-run `yarn`.**