### PR TITLE
Feature/123 event resource list endpoints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,4 +6,9 @@ jobs:
    - image: holochain/holonix:latest
   steps:
    - checkout
-   - run: nix-shell --run 'yarn && npm run build && npm run test:integration'
+   - run:
+       name: sim2h server
+       command: nix-shell --run 'npm run dht:sim2h'
+       background: true
+       no_output_timeout: 20m
+   - run: nix-shell --run 'yarn && npm run build && npm run test:integration:test'

--- a/happs/observation/zomes/economic_event/code/src/lib.rs
+++ b/happs/observation/zomes/economic_event/code/src/lib.rs
@@ -15,7 +15,7 @@ extern crate hdk_proc_macros;
 use hdk::prelude::*;
 use hdk_proc_macros::zome;
 
-use hc_zome_rea_economic_event_defs::{ entry_def, base_entry_def };
+use hc_zome_rea_economic_event_defs::*;
 use hc_zome_rea_economic_event_lib::*;
 use hc_zome_rea_economic_event_rpc::*;
 use hc_zome_rea_economic_resource_rpc::CreateRequest as EconomicResourceCreateRequest;
@@ -41,6 +41,11 @@ mod rea_economic_event_zome {
     #[entry_def]
     fn event_base_entry_def() -> ValidatingEntryType {
         base_entry_def()
+    }
+
+    #[entry_def]
+    fn event_root_entry_def() -> ValidatingEntryType {
+        root_entry_def()
     }
 
     #[zome_fn("hc_public")]

--- a/happs/observation/zomes/economic_event/code/src/lib.rs
+++ b/happs/observation/zomes/economic_event/code/src/lib.rs
@@ -64,6 +64,11 @@ mod rea_economic_event_zome {
     }
 
     #[zome_fn("hc_public")]
+    fn get_all_events() -> ZomeApiResult<Vec<ResponseData>> {
+        receive_get_all_economic_events()
+    }
+
+    #[zome_fn("hc_public")]
     fn query_events(params: QueryParams) -> ZomeApiResult<Vec<ResponseData>> {
         receive_query_events(params)
     }

--- a/happs/observation/zomes/economic_resource/code/src/lib.rs
+++ b/happs/observation/zomes/economic_resource/code/src/lib.rs
@@ -18,7 +18,7 @@ use hdk_proc_macros::zome;
 use hc_zome_rea_resource_specification_storage_consts::{ ECONOMIC_RESOURCE_SPECIFICATION_BASE_ENTRY_TYPE, RESOURCE_SPECIFICATION_CONFORMING_RESOURCE_LINK_TYPE };
 use hc_zome_rea_economic_resource_storage_consts::RESOURCE_BASE_ENTRY_TYPE;
 
-use hc_zome_rea_economic_resource_defs::{ entry_def, base_entry_def };
+use hc_zome_rea_economic_resource_defs::*;
 use hc_zome_rea_economic_resource_lib::*;
 use hc_zome_rea_economic_resource_rpc::*;
 use hc_zome_rea_economic_event_rpc::ResourceResponseData as ResponseData;
@@ -44,6 +44,11 @@ mod rea_economic_resource_zome {
     #[entry_def]
     fn resource_base_entry_def() -> ValidatingEntryType {
         base_entry_def()
+    }
+
+    #[entry_def]
+    fn resource_root_entry_def() -> ValidatingEntryType {
+        root_entry_def()
     }
 
     // :TODO: move to separate zome

--- a/happs/observation/zomes/economic_resource/code/src/lib.rs
+++ b/happs/observation/zomes/economic_resource/code/src/lib.rs
@@ -84,6 +84,11 @@ mod rea_economic_resource_zome {
         receive_update_economic_resource(resource)
     }
 
+    #[zome_fn("hc_public")]
+    fn get_all_resources() -> ZomeApiResult<Vec<ResponseData>> {
+        receive_get_all_economic_resources()
+    }
+
 
     #[zome_fn("hc_public")]
     fn query_resources(params: QueryParams) -> ZomeApiResult<Vec<ResponseData>> {

--- a/lib/hdk_graph_helpers/src/anchor_helpers.rs
+++ b/lib/hdk_graph_helpers/src/anchor_helpers.rs
@@ -56,8 +56,7 @@ pub fn get_anchor_index_entry_address<E>(
 ///
 /// Follows an anchor identified by `anchor_entry_type`, `anchor_link_type` and
 /// some well-known `anchor_string` to retrieve the set of entries of type `T`
-/// that are linked via their own `key indexes` following `record_link_type`
-/// and `record_link_name`.
+/// that are linked via their own `key indexes`.
 ///
 /// Works like reading an unfiltered list of records from a database table.
 ///

--- a/lib/hdk_graph_helpers/src/anchor_helpers.rs
+++ b/lib/hdk_graph_helpers/src/anchor_helpers.rs
@@ -26,7 +26,7 @@ use hdk::{
 };
 
 use super::{
-    identifiers::{ ANCHOR_POINTER_LINK_TAG, ERR_MSG_ENTRY_NOT_FOUND, ERR_MSG_INDEX_NOT_FOUND },
+    identifiers::{ ANCHOR_POINTER_LINK_TAG, ERR_MSG_ENTRY_NOT_FOUND },
     links::{
         get_linked_addresses,
     },
@@ -70,23 +70,15 @@ pub fn read_anchored_record_entries<T, E, A>(
     anchor_entry_type: &E,
     anchor_link_type: &str,
     anchor_string: &String,
-    record_link_type: &str,
-    record_link_name: &str,
 ) -> ZomeApiResult<Vec<(A, Option<T>)>>
     where E: Into<AppEntryType> + Clone,
         A: From<Address>,
         T: Clone + TryFrom<AppEntryValue>,
 {
     // determine ID anchor entry address
-    let entry_address = get_anchor_index_entry_address(anchor_entry_type, anchor_link_type, anchor_string)?;
-
-    // query the indexed records linked from the query anchor
-    match entry_address {
-        None => Err(ZomeApiError::Internal(ERR_MSG_INDEX_NOT_FOUND.to_string())),
-        Some(entry_addr) => {
-            query_direct_index_with_foreign_key(&Addressable::from(entry_addr), record_link_type, record_link_name)
-        },
-    }
+    let anchor_address = determine_anchor_index_address(anchor_entry_type, anchor_string)?;
+    // retrieve the indexed records by querying the anchor index
+    query_direct_index_with_foreign_key(&Addressable::from(anchor_address), anchor_link_type, ANCHOR_POINTER_LINK_TAG)
 }
 
 fn determine_anchor_index_address<E>(

--- a/lib/hdk_graph_helpers/src/lib.rs
+++ b/lib/hdk_graph_helpers/src/lib.rs
@@ -49,4 +49,5 @@ pub mod identifiers {
     pub const ERR_MSG_REMOTE_INDEXING_ERR: &str = "Indexing error in remote DNA call ";
     pub const ERR_MSG_REMOTE_REQUEST_ERR: &str = "Error in zome RPC call ";
     pub const ERR_MSG_REMOTE_RESPONSE_FORMAT_ERR: &str = "Bad zome RPC response format from ";
+    pub const ERR_MSG_INDEX_NOT_FOUND: &str = "Given index does not exist";
 }

--- a/lib/rea_economic_event/defs/src/lib.rs
+++ b/lib/rea_economic_event/defs/src/lib.rs
@@ -125,3 +125,31 @@ pub fn base_entry_def() -> ValidatingEntryType {
         ]
     )
 }
+
+pub fn root_entry_def() -> ValidatingEntryType {
+    entry!(
+        name: EVENT_INDEX_ROOT_ENTRY_TYPE,
+        description: "Root anchor which connects to all Economic Events stored in this zome.",
+        sharing: Sharing::Public,
+        validation_package: || {
+            hdk::ValidationPackageDefinition::Entry
+        },
+        validation: |_validation_data: hdk::EntryValidationData<Address>| {
+            Ok(())
+        },
+        links: [
+            to!(
+                EVENT_BASE_ENTRY_TYPE,
+                link_type: EVENT_INDEX_ENTRY_LINK_TYPE,
+
+                validation_package: || {
+                    hdk::ValidationPackageDefinition::Entry
+                },
+
+                validation: | _validation_data: hdk::LinkValidationData| {
+                    Ok(())
+                }
+            )
+        ]
+    )
+}

--- a/lib/rea_economic_event/lib/src/lib.rs
+++ b/lib/rea_economic_event/lib/src/lib.rs
@@ -296,7 +296,6 @@ fn handle_delete_economic_event(address: &EventAddress) -> ZomeApiResult<bool> {
 fn handle_get_all_economic_events() -> ZomeApiResult<Vec<ResponseData>> {
     let entries_result: ZomeApiResult<Vec<(EventAddress, Option<Entry>)>> = read_anchored_record_entries(
         &EVENT_INDEX_ROOT_ENTRY_TYPE.to_string(), EVENT_INDEX_ENTRY_LINK_TYPE, &EVENT_INDEX_ROOT_ENTRY_ID.to_string(),
-        EVENT_ENTRY_TYPE, EVENT_INITIAL_ENTRY_LINK_TYPE,
     );
 
     handle_list_output(entries_result)

--- a/lib/rea_economic_event/lib/src/lib.rs
+++ b/lib/rea_economic_event/lib/src/lib.rs
@@ -163,6 +163,10 @@ pub fn receive_delete_economic_event(address: EventAddress) -> ZomeApiResult<boo
     handle_delete_economic_event(&address)
 }
 
+pub fn receive_get_all_economic_events() -> ZomeApiResult<Vec<ResponseData>> {
+    handle_get_all_economic_events()
+}
+
 pub fn receive_query_events(params: QueryParams) -> ZomeApiResult<Vec<ResponseData>> {
     handle_query_events(&params)
 }
@@ -291,6 +295,15 @@ fn handle_delete_economic_event(address: &EventAddress) -> ZomeApiResult<bool> {
     delete_record::<Entry>(&address)
 }
 
+fn handle_get_all_economic_events() -> ZomeApiResult<Vec<ResponseData>> {
+    let entries_result: ZomeApiResult<Vec<(EventAddress, Option<Entry>)>> = read_anchored_record_entries(
+        &EVENT_INDEX_ROOT_ENTRY_TYPE.to_string(), EVENT_INDEX_ENTRY_LINK_TYPE, &EVENT_INDEX_ROOT_ENTRY_ID.to_string(),
+        EVENT_ENTRY_TYPE, EVENT_INITIAL_ENTRY_LINK_TYPE,
+    );
+
+    handle_list_output(entries_result)
+}
+
 fn handle_query_events(params: &QueryParams) -> ZomeApiResult<Vec<ResponseData>> {
     let mut entries_result: ZomeApiResult<Vec<(EventAddress, Option<Entry>)>> = Err(ZomeApiError::Internal("No results found".to_string()));
 
@@ -328,6 +341,10 @@ fn handle_query_events(params: &QueryParams) -> ZomeApiResult<Vec<ResponseData>>
         _ => (),
     };
 
+    handle_list_output(entries_result)
+}
+
+fn handle_list_output(entries_result: ZomeApiResult<Vec<(EventAddress, Option<Entry>)>>) -> ZomeApiResult<Vec<ResponseData>> {
     match entries_result {
         Ok(entries) => Ok(
             entries.iter()

--- a/lib/rea_economic_event/storage_consts/src/lib.rs
+++ b/lib/rea_economic_event/storage_consts/src/lib.rs
@@ -16,3 +16,8 @@ pub const EVENT_INPUT_OF_LINK_TYPE: &str = "vf_economic_event_input_of";
 pub const EVENT_INPUT_OF_LINK_TAG: &str = "input_of";
 pub const EVENT_OUTPUT_OF_LINK_TYPE: &str = "vf_economic_event_output_of";
 pub const EVENT_OUTPUT_OF_LINK_TAG: &str = "output_of";
+
+// :TODO: replace with a DAG
+pub const EVENT_INDEX_ROOT_ENTRY_TYPE: &str = "vf_economic_events_root";
+pub const EVENT_INDEX_ROOT_ENTRY_ID: &str = "all_vf_economic_events";
+pub const EVENT_INDEX_ENTRY_LINK_TYPE: &str = "vf_economic_event_root_index";

--- a/lib/rea_economic_resource/defs/src/lib.rs
+++ b/lib/rea_economic_resource/defs/src/lib.rs
@@ -110,3 +110,31 @@ pub fn base_entry_def() -> ValidatingEntryType {
         ]
     )
 }
+
+pub fn root_entry_def() -> ValidatingEntryType {
+    entry!(
+        name: RESOURCE_INDEX_ROOT_ENTRY_TYPE,
+        description: "Root anchor which connects to all Economic Resources stored in this zome.",
+        sharing: Sharing::Public,
+        validation_package: || {
+            hdk::ValidationPackageDefinition::Entry
+        },
+        validation: |_validation_data: hdk::EntryValidationData<Address>| {
+            Ok(())
+        },
+        links: [
+            to!(
+                RESOURCE_BASE_ENTRY_TYPE,
+                link_type: RESOURCE_INDEX_ENTRY_LINK_TYPE,
+
+                validation_package: || {
+                    hdk::ValidationPackageDefinition::Entry
+                },
+
+                validation: | _validation_data: hdk::LinkValidationData| {
+                    Ok(())
+                }
+            )
+        ]
+    )
+}

--- a/lib/rea_economic_resource/lib/src/lib.rs
+++ b/lib/rea_economic_resource/lib/src/lib.rs
@@ -87,7 +87,6 @@ fn handle_update_economic_resource(resource: &UpdateRequest) -> ZomeApiResult<Re
 fn handle_get_all_economic_resources() -> ZomeApiResult<Vec<ResponseData>> {
     let entries_result: ZomeApiResult<Vec<(ResourceAddress, Option<Entry>)>> = read_anchored_record_entries(
         &RESOURCE_INDEX_ROOT_ENTRY_TYPE.to_string(), RESOURCE_INDEX_ENTRY_LINK_TYPE, &RESOURCE_INDEX_ROOT_ENTRY_ID.to_string(),
-        RESOURCE_ENTRY_TYPE, RESOURCE_INITIAL_ENTRY_LINK_TYPE,
     );
 
     handle_list_output(entries_result)

--- a/lib/rea_economic_resource/storage_consts/src/lib.rs
+++ b/lib/rea_economic_resource/storage_consts/src/lib.rs
@@ -17,4 +17,9 @@ pub const RESOURCE_AFFECTED_BY_EVENT_LINK_TAG: &str = "affected_by";
 pub const RESOURCE_CONFORMS_TO_LINK_TYPE: &str = "vf_economic_resource_conforms_to";
 pub const RESOURCE_CONFORMS_TO_LINK_TAG: &str = "conforms_to";
 
+// :TODO: replace with a DAG
+pub const RESOURCE_INDEX_ROOT_ENTRY_TYPE: &str = "vf_economic_resources_root";
+pub const RESOURCE_INDEX_ROOT_ENTRY_ID: &str = "all_vf_economic_resources";
+pub const RESOURCE_INDEX_ENTRY_LINK_TYPE: &str = "vf_economic_resource_root_index";
+
 pub const BRIDGED_SPECIFICATION_DHT: &str = "vf_specification";

--- a/modules/vf-graphql-holochain/connection.ts
+++ b/modules/vf-graphql-holochain/connection.ts
@@ -64,7 +64,7 @@ export interface ZomeFnOpts {
 /**
  * Higher-order function to generate async functions for calling zome RPC methods
  */
-export const zomeFunction = (instance: string, zome: string, fn: string, socketURI: ConnURI = undefined) => async (args: any = undefined, opts: ZomeFnOpts = {}) => {
+export const zomeFunction = (instance: string, zome: string, fn: string, socketURI: ConnURI = undefined) => async (args: any, opts: ZomeFnOpts = {}) => {
   const { callZome } = await BASE_CONNECTION(socketURI)
   const zomeCall = callZome(instance, zome, fn)
 

--- a/modules/vf-graphql-holochain/connection.ts
+++ b/modules/vf-graphql-holochain/connection.ts
@@ -64,7 +64,7 @@ export interface ZomeFnOpts {
 /**
  * Higher-order function to generate async functions for calling zome RPC methods
  */
-export const zomeFunction = (instance: string, zome: string, fn: string, socketURI: ConnURI = undefined) => async (args: any, opts: ZomeFnOpts = {}) => {
+export const zomeFunction = (instance: string, zome: string, fn: string, socketURI: ConnURI = undefined) => async (args: any = undefined, opts: ZomeFnOpts = {}) => {
   const { callZome } = await BASE_CONNECTION(socketURI)
   const zomeCall = callZome(instance, zome, fn)
 

--- a/modules/vf-graphql-holochain/queries/economicEvent.ts
+++ b/modules/vf-graphql-holochain/queries/economicEvent.ts
@@ -6,7 +6,7 @@
  */
 
 import { zomeFunction } from '../connection'
-import { injectTypename } from '../types'
+import { injectTypename, addTypename } from '../types'
 
 import {
   EconomicEvent,
@@ -16,11 +16,13 @@ import {
 const readOne = zomeFunction('observation', 'economic_event', 'get_event')
 const readAll = zomeFunction('observation', 'economic_event', 'get_all_events')
 
+const withTypename = addTypename('EconomicEvent')
+
 // Read a single event by ID
 export const economicEvent = injectTypename('EconomicEvent', async (root, args): Promise<EconomicEvent> => {
   return (await readOne({ address: args.id })).economicEvent
 })
 
 export const allEconomicEvents = async (root, args): Promise<[EconomicEvent]> => {
-  return (await readAll()).map(e => injectTypename('EconomicEvent', e.economicEvent))
+  return (await readAll({})).map(e => withTypename(e.economicEvent))
 }

--- a/modules/vf-graphql-holochain/queries/economicEvent.ts
+++ b/modules/vf-graphql-holochain/queries/economicEvent.ts
@@ -13,10 +13,14 @@ import {
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
-const readEvent = zomeFunction('observation', 'economic_event', 'get_event')
+const readOne = zomeFunction('observation', 'economic_event', 'get_event')
+const readAll = zomeFunction('observation', 'economic_event', 'get_all_events')
 
 // Read a single event by ID
 export const economicEvent = injectTypename('EconomicEvent', async (root, args): Promise<EconomicEvent> => {
-  const { id } = args
-  return (await (await readEvent)({ address: id })).economicEvent
+  return (await readOne({ address: args.id })).economicEvent
 })
+
+export const allEconomicEvents = async (root, args): Promise<[EconomicEvent]> => {
+  return (await readAll()).map(e => injectTypename('EconomicEvent', e.economicEvent))
+}

--- a/modules/vf-graphql-holochain/queries/economicResource.ts
+++ b/modules/vf-graphql-holochain/queries/economicResource.ts
@@ -12,9 +12,14 @@ import {
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
-const readResource = zomeFunction('observation', 'economic_resource', 'get_resource')
+const readOne = zomeFunction('observation', 'economic_resource', 'get_resource')
+const readAll = zomeFunction('observation', 'economic_resource', 'get_all_resources')
 
 // Read a single record by ID
 export const economicResource = async (root, args): Promise<EconomicResource> => {
-  return (await readResource({ address: args.id })).economicResource
+  return (await readOne({ address: args.id })).economicResource
+}
+
+export const allEconomicResources = async (root, args): Promise<[EconomicResource]> => {
+  return (await readAll()).map(e => e.economicResource)
 }

--- a/modules/vf-graphql-holochain/queries/economicResource.ts
+++ b/modules/vf-graphql-holochain/queries/economicResource.ts
@@ -21,5 +21,5 @@ export const economicResource = async (root, args): Promise<EconomicResource> =>
 }
 
 export const allEconomicResources = async (root, args): Promise<[EconomicResource]> => {
-  return (await readAll()).map(e => e.economicResource)
+  return (await readAll({})).map(e => e.economicResource)
 }

--- a/test/economic-event/event_resource_list_api.js
+++ b/test/economic-event/event_resource_list_api.js
@@ -1,0 +1,142 @@
+const {
+  getDNA,
+  buildConfig,
+  buildRunner,
+  buildPlayer,
+} = require('../init')
+
+const runner = buildRunner()
+
+const config = buildConfig({
+  observation: getDNA('observation'),
+})
+
+const testEventProps = {
+  action: 'raise',
+  provider: 'agentid-1-todo',
+  receiver: 'agentid-2-todo',
+  resourceQuantity: { hasNumericalValue: 1, hasUnit: 'unit-todo-tidy-up' },
+}
+
+runner.registerScenario('Event/Resource list APIs', async (s, t) => {
+  const alice = await buildPlayer(s, 'alice', config)
+
+  let resp = await alice.graphQL(`
+    mutation(
+      $e1: EconomicEventCreateParams!,
+      $r1: EconomicResourceCreateParams!,
+      $e2: EconomicEventCreateParams!,
+      $r2: EconomicResourceCreateParams!,
+    ) {
+      r1: createEconomicEvent(event: $e1, newInventoriedResource: $r1) {
+        economicEvent {
+          id
+        }
+        economicResource {
+          id
+        }
+      }
+      r2: createEconomicEvent(event: $e2, newInventoriedResource: $r2) {
+        economicEvent {
+          id
+        }
+        economicResource {
+          id
+        }
+      }
+    }
+  `, {
+    e1: {
+      resourceClassifiedAs: ['some-type-of-resource'],
+      hasPointInTime: '2019-11-19T04:29:55.000Z',
+      ...testEventProps,
+    },
+    r1: { note: 'resource A' },
+    e2: {
+      resourceClassifiedAs: ['another-type-of-resource'],
+      hasPointInTime: '2019-11-19T04:29:56.000Z',
+      ...testEventProps,
+    },
+    r2: { note: 'resource B' },
+  })
+  await s.consistency()
+
+  t.ok(resp.data.r1.economicResource.id, 'first resource created')
+  t.ok(resp.data.r2.economicResource.id, 'second resource created')
+  t.ok(resp.data.r1.economicEvent.id, 'first event created')
+  t.ok(resp.data.r2.economicEvent.id, 'second event created')
+  const resource1Id = resp.data.r1.economicResource.id
+  const resource2Id = resp.data.r2.economicResource.id
+  const event1Id = resp.data.r1.economicEvent.id
+  const event2Id = resp.data.r2.economicEvent.id
+
+  resp = await alice.graphQL(`mutation(
+    $e1: EconomicEventCreateParams!,
+    $e2: EconomicEventCreateParams!,
+    $e3: EconomicEventCreateParams!,
+  ) {
+    e1: createEconomicEvent(event: $e1) {
+      economicEvent {
+        id
+      }
+    }
+    e2: createEconomicEvent(event: $e2) {
+      economicEvent {
+        id
+      }
+    }
+    e3: createEconomicEvent(event: $e3) {
+      economicEvent {
+        id
+      }
+    }
+  }`, {
+    e1: {
+      resourceInventoriedAs: resource1Id,
+      hasPointInTime: '2019-11-20T04:29:55.000Z',
+      ...testEventProps,
+    },
+    e2: {
+      resourceInventoriedAs: resource1Id,
+      hasPointInTime: '2019-11-21T04:29:55.000Z',
+      ...testEventProps,
+    },
+    e3: {
+      resourceInventoriedAs: resource2Id,
+      hasPointInTime: '2019-11-22T04:29:55.000Z',
+      ...testEventProps,
+    },
+  })
+  await s.consistency()
+
+  t.ok(resp.data.e1.economicEvent.id, '1st additional event created')
+  t.ok(resp.data.e2.economicEvent.id, '2nd additional event created')
+  t.ok(resp.data.e3.economicEvent.id, '3rd additional event created')
+  const event3Id = resp.data.e1.economicEvent.id
+  const event4Id = resp.data.e2.economicEvent.id
+  const event5Id = resp.data.e3.economicEvent.id
+
+  resp = await alice.graphQL(`{
+    allEconomicEvents {
+      id
+    }
+    allEconomicResources {
+      id
+    }
+  }`)
+
+  t.equal(resp.data.allEconomicEvents.length, 5, 'all events correctly retrievable')
+  t.deepEqual(
+    resp.data.allEconomicEvents,
+    [{ id: event1Id }, { id: event2Id }, { id: event3Id }, { id: event4Id }, { id: event5Id }],
+    'event IDs OK'
+  )
+  t.equal(resp.data.allEconomicResources.length, 2, 'all resources correctly retrievable')
+  t.deepEqual(
+    resp.data.allEconomicResources,
+    [{ id: resource1Id }, { id: resource2Id }],
+    'resource IDs OK'
+  )
+})
+
+runner.run()


### PR DESCRIPTION
Implements a very basic list API for events & resources (which will have DHT hotspots / performance implications, and eventually needs to be replaced with a DAG implementation that supports pagination).

Also changes the logic for `EconomicEvents` such that any `EconomicResource` specified as `toResourceInventoriedAs` will track the referencing event as an event which has affected the resource. This is an unrelated item that came from recent conversations with @fosterlynn whereby the destination inventory needs to track events in the same way as the sender.

Also fixes the CI config so that sim2h does not indefinitely run and prevent the integration tests from completing. (However, we seem to get continual network issues from Circle so might have to switch anyway.)