### PR TITLE
Feature/modular graphql integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ branches:
   only:
   - master
   - /^(feature|release|hotfix)\/.*/
-cache:
-  directories:
-  - "/tmp/holochain/target"
-  yarn: true
-  cargo: true
+# cache:
+#   directories:
+#   - "/tmp/holochain/target"
+#   yarn: true
+#   cargo: true

--- a/apps/holorea-graphql-explorer/package.json
+++ b/apps/holorea-graphql-explorer/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@valueflows/vf-graphql-holochain": "0.0.1-alpha.1",
+    "@valueflows/vf-graphql-holochain": "0.0.1-alpha.2",
     "apollo-link": "^1.2.11",
     "apollo-link-schema": "^1.2.2",
     "graphiql": "^0.13.0",

--- a/modules/vf-graphql-holochain/index.ts
+++ b/modules/vf-graphql-holochain/index.ts
@@ -9,7 +9,7 @@
  */
 
 import { makeExecutableSchema } from 'graphql-tools'
-import { all_vf as typeDefs } from '@valueflows/vf-graphql/typeDefs'
+import typeDefs from '@valueflows/vf-graphql/ALL_VF_SDL'
 
 import * as resolvers from './resolvers'
 

--- a/modules/vf-graphql-holochain/index.ts
+++ b/modules/vf-graphql-holochain/index.ts
@@ -9,9 +9,9 @@
  */
 
 import { makeExecutableSchema } from 'graphql-tools'
-import typeDefs from '@valueflows/vf-graphql/ALL_VF_SDL'
 
 import * as resolvers from './resolvers'
+const { buildSchema, printSchema } = require('@valueflows/vf-graphql')
 
 // direct access to resolver callbacks and connection URI for apps that need it
 export { setConnectionURI } from './connection'
@@ -19,6 +19,10 @@ export { resolvers }
 
 // default export is the full schema ready to be plugged in to a GraphQL client
 export default makeExecutableSchema({
-  typeDefs,
+  typeDefs: printSchema(buildSchema([
+    'knowledge', 'measurement',
+    'agent',
+    'observation', 'planning', 'proposal',
+  ])),
   resolvers,
 })

--- a/modules/vf-graphql-holochain/package.json
+++ b/modules/vf-graphql-holochain/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/holo-rea/holo-rea#readme",
   "dependencies": {
     "@holochain/hc-web-client": "0.5.0",
-    "@valueflows/vf-graphql": "0.6.0",
+    "@valueflows/vf-graphql": "0.6.1",
     "dataloader": "^1.4.0",
     "fecha": "^3.0.3",
     "graphql": "14.5.8",

--- a/modules/vf-graphql-holochain/package.json
+++ b/modules/vf-graphql-holochain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valueflows/vf-graphql-holochain",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "private": true,
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/holo-rea/holo-rea#readme",
   "dependencies": {
     "@holochain/hc-web-client": "0.5.0",
-    "@valueflows/vf-graphql": "0.4.2",
+    "@valueflows/vf-graphql": "0.6.0",
     "dataloader": "^1.4.0",
     "fecha": "^3.0.3",
     "graphql": "14.5.8",

--- a/test/init.js
+++ b/test/init.js
@@ -18,7 +18,7 @@ const { Orchestrator, Config, combine, tapeExecutor, localOnly } = require('@hol
 const { GraphQLError } = require('graphql')
 const GQLTester = require('easygraphql-tester')
 const resolverLoggerMiddleware = require('./graphql-logger-middleware')
-const { all_vf: schema } = require('@valueflows/vf-graphql/typeDefs')
+const schema = require('@valueflows/vf-graphql/ALL_VF_SDL')
 const { resolvers, setConnectionURI } = require('@valueflows/vf-graphql-holochain')
 
 process.on('unhandledRejection', error => {

--- a/test/package.json
+++ b/test/package.json
@@ -8,8 +8,8 @@
   },
   "devDependencies": {
     "@holochain/tryorama": "git://github.com/holochain/tryorama.git#cbcc80d",
-    "@valueflows/vf-graphql": "0.4.2",
-    "@valueflows/vf-graphql-holochain": "0.0.1-alpha.1",
+    "@valueflows/vf-graphql": "0.6.0",
+    "@valueflows/vf-graphql-holochain": "0.0.1-alpha.2",
     "deep-for-each": "^3.0.0",
     "easygraphql-tester": "5.1.6",
     "eslint": "^5.16.0",

--- a/test/package.json
+++ b/test/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@holochain/tryorama": "git://github.com/holochain/tryorama.git#cbcc80d",
-    "@valueflows/vf-graphql": "0.6.0",
+    "@valueflows/vf-graphql": "0.6.1",
     "@valueflows/vf-graphql-holochain": "0.0.1-alpha.2",
     "deep-for-each": "^3.0.0",
     "easygraphql-tester": "5.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1694,26 +1694,6 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@valueflows/vf-graphql-holochain@0.0.1-alpha.1":
-  version "0.0.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/@valueflows/vf-graphql-holochain/-/vf-graphql-holochain-0.0.1-alpha.1.tgz#f828a13f922ebdbd702c996e9a4e90e0b474a41f"
-  integrity sha512-H1Aso5YP+nGOi8Ega+empLCNzkIR9knRkzRWModtee90dgvvO4Ijcgfc5qc8Kha/gHddsl+hnbUKLxkDSt3G2w==
-  dependencies:
-    "@holochain/hc-web-client" "0.5.0"
-    "@valueflows/vf-graphql" "0.4.2"
-    dataloader "^1.4.0"
-    fecha "^3.0.3"
-    graphql "14.5.8"
-    graphql-tools "4.0.4"
-
-"@valueflows/vf-graphql@0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@valueflows/vf-graphql/-/vf-graphql-0.4.2.tgz#964a886bbad4045acdb17b9578ca62be75d1b83e"
-  integrity sha512-3WuS5HURPDw3il1OJro8MwcMbPzRyi4LKbj3Q5F+WbAHFCxErT7VCBkmEmr6CZQx2QxnVaaap0j4ntOiyMHhxA==
-  dependencies:
-    graphql "14.5.8"
-    graphql-tools "4.0.6"
-
 "@valueflows/vf-graphql@0.6.1":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@valueflows/vf-graphql/-/vf-graphql-0.6.1.tgz#b5719e79df481935c5a41bf105c7a964ab5395ce"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,6 +11,17 @@
     deep-eql "^0.1.3"
     keypather "^1.10.2"
 
+"@ardatan/graphql-tools@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@ardatan/graphql-tools/-/graphql-tools-4.1.0.tgz#183508ef4e3d4966f763cb1634a81be1c1255f8d"
+  integrity sha512-0b+KH5RZN9vCMpEjxrwFwZ7v3K6QDjs1EH+R6eRrgKMR2X274JWqYraHKLWE1uJ8iwrkRaOYfCV12jLVuvWS+A==
+  dependencies:
+    apollo-link "^1.2.3"
+    apollo-utilities "^1.0.1"
+    deprecated-decorator "^0.1.6"
+    iterall "^1.1.3"
+    uuid "^3.1.0"
+
 "@babel/code-frame@7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -1099,6 +1110,25 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-9.0.1.tgz#c27b391d8457d1e893f1eddeaf5e5412d12ffbb5"
   integrity sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA==
 
+"@graphql-toolkit/common@0.9.7":
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/@graphql-toolkit/common/-/common-0.9.7.tgz#63bc6233c4fd88bc94dfe6a3ec85b8f961f780f9"
+  integrity sha512-dpSRBMLeIiRct2gkjj24bp0EV7hbK/7dpJAPqNgvDH2535LhOkprYiCXQJyP4N1LODAEkpN/zzlJfKMVn773MQ==
+  dependencies:
+    "@ardatan/graphql-tools" "4.1.0"
+    aggregate-error "3.0.1"
+    lodash "4.17.15"
+
+"@graphql-toolkit/schema-merging@^0.9.7":
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/@graphql-toolkit/schema-merging/-/schema-merging-0.9.7.tgz#241ddd2c9ba79dd4444014057d0765777ab3cd12"
+  integrity sha512-RLhP0+XT4JGoPGCvlcTPdCE8stA7l0D5+gZ8ZP0snqzZOdsDFG4cNxpJtwf48i7uArsXkfu5OjOvTwh0MR0Wrw==
+  dependencies:
+    "@ardatan/graphql-tools" "4.1.0"
+    "@graphql-toolkit/common" "0.9.7"
+    deepmerge "4.2.2"
+    tslib "1.10.0"
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
@@ -1664,11 +1694,32 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
+"@valueflows/vf-graphql-holochain@0.0.1-alpha.1":
+  version "0.0.1-alpha.1"
+  resolved "https://registry.yarnpkg.com/@valueflows/vf-graphql-holochain/-/vf-graphql-holochain-0.0.1-alpha.1.tgz#f828a13f922ebdbd702c996e9a4e90e0b474a41f"
+  integrity sha512-H1Aso5YP+nGOi8Ega+empLCNzkIR9knRkzRWModtee90dgvvO4Ijcgfc5qc8Kha/gHddsl+hnbUKLxkDSt3G2w==
+  dependencies:
+    "@holochain/hc-web-client" "0.5.0"
+    "@valueflows/vf-graphql" "0.4.2"
+    dataloader "^1.4.0"
+    fecha "^3.0.3"
+    graphql "14.5.8"
+    graphql-tools "4.0.4"
+
 "@valueflows/vf-graphql@0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@valueflows/vf-graphql/-/vf-graphql-0.4.2.tgz#964a886bbad4045acdb17b9578ca62be75d1b83e"
   integrity sha512-3WuS5HURPDw3il1OJro8MwcMbPzRyi4LKbj3Q5F+WbAHFCxErT7VCBkmEmr6CZQx2QxnVaaap0j4ntOiyMHhxA==
   dependencies:
+    graphql "14.5.8"
+    graphql-tools "4.0.6"
+
+"@valueflows/vf-graphql@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@valueflows/vf-graphql/-/vf-graphql-0.6.1.tgz#b5719e79df481935c5a41bf105c7a964ab5395ce"
+  integrity sha512-uenzygh69Fi+D4LVVOu4bd+n98sg50D3l4SI/0cM+8c/raHsoSA5RjY5SQJSVtSUuNng9ira3QrrdwqHZccP/w==
+  dependencies:
+    "@graphql-toolkit/schema-merging" "^0.9.7"
     graphql "14.5.8"
     graphql-tools "4.0.6"
 
@@ -1903,6 +1954,14 @@ aggregate-error@3.0.0:
   dependencies:
     clean-stack "^2.0.0"
     indent-string "^3.2.0"
+
+aggregate-error@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
+  integrity sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==
+  dependencies:
+    clean-stack "^2.0.0"
+    indent-string "^4.0.0"
 
 ajv-errors@^1.0.0:
   version "1.0.1"
@@ -3953,6 +4012,11 @@ deepmerge@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.0.0.tgz#3e3110ca29205f120d7cb064960a39c3d2087c09"
   integrity sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww==
+
+deepmerge@4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
 default-gateway@^4.2.0:
   version "4.2.0"
@@ -6281,6 +6345,11 @@ indent-string@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
   integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
+
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
 indexes-of@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This integrates a drastically improved `vf-graphql` module which allows dynamic generation of an API schema based on modular inputs.

You can see this in action in the index file of `vf-graphql-holochain`. It no longer uses the whole schema, only the modules which are currently implemented (or almost implemented) in Holo-REA.

This means the query interface offered in the Holo-REA GraphQL explorer will be a sub-set of the complete set available in `vf-graphql`. And it also makes the system less daunting overall and easier to pick out the API endpoints which are actually functional.

Note that you'll need to run `npm run clean:modules && yarn` after switching to this code to ensure you have the correct new modules wired up.