### PR TITLE
Feature/135 inscopeof fix

### DIFF
--- a/modules/vf-graphql-holochain/types.ts
+++ b/modules/vf-graphql-holochain/types.ts
@@ -43,10 +43,20 @@ export const AnyType = new GraphQLScalarType({
   name: 'AnyType',
   description: 'A type which allows any arbitrary value to be set',
   serialize: (v) => JSON.stringify(v),
-  parseValue: (v) => JSON.parse(v),
+  parseValue: (v) => {
+    try {
+      return JSON.parse(v)
+    } catch (e) {
+      return v
+    }
+  },
   parseLiteral (ast) {
     if (ast.kind === Kind.STRING) {
-      return JSON.parse(ast.value)
+      try {
+        return JSON.parse(ast.value)
+      } catch (e) {
+        return ast.value
+      }
     }
     return null
   },

--- a/test/economic-event/test_basic_ops.js
+++ b/test/economic-event/test_basic_ops.js
@@ -21,12 +21,14 @@ runner.registerScenario('create simplest event', async (s, t) => {
     hasPointInTime: '2019-11-19T12:12:42.739Z',
     resourceClassifiedAs: ['some-resource-type'],
     resourceQuantity: { hasNumericalValue: 1 },
+    inScopeOf: ['some-accounting-scope'],
   }
 
   const createEventResponse = await alice.call('observation', 'economic_event', 'create_event', { event })
   await s.consistency()
 
-  t.ok(createEventResponse.Ok.economicEvent)
+  t.ok(createEventResponse.Ok.economicEvent, 'event created')
+  t.deepEqual(createEventResponse.Ok.economicEvent.inScopeOf, ['some-accounting-scope'], 'event inScopeOf saved')
 })
 
 runner.run()


### PR DESCRIPTION
This should fix `AnyType` crashing when it's not storing JSON- now asserting this in the `EconomicEvent` "simple record" test