### PR TITLE
agents call was broken due to bad zome fn name

### DIFF
--- a/modules/vf-graphql-holochain/queries/agent.ts
+++ b/modules/vf-graphql-holochain/queries/agent.ts
@@ -16,7 +16,7 @@ import {
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
   const readMyAgent = mapZomeFn(dnaConfig, conductorUri, 'agent', 'agent_registration', 'get_my_agent_pubkey')
-  const readAllAgents = mapZomeFn(dnaConfig, conductorUri, 'agent', 'agent_registration', 'get_registered_agents')
+  const readAllAgents = mapZomeFn(dnaConfig, conductorUri, 'agent', 'agent_registration', 'get_registered')
   // special 'true' at the end is for skipEncodeDecode, because of the way this zome handles serialization and inputs
   // which is different from others
   const agentExists = mapZomeFn(dnaConfig, conductorUri, 'agent', 'agent_registration', 'is_registered', true)


### PR DESCRIPTION
https://github.com/holochain-open-dev/agent-registration/blob/a37cc26ebabf49bb8ce3ec48b1e8548f975fe986/zome/zome/src/lib.rs#L30

Update: disregard this PR, it is not enough to fix `agents`. After hacking agents further to get it to work, I realize that the response is actually coming back an empty array, which makes no sense