### PR TITLE
fix the missing entry def for units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,6 +1229,7 @@ dependencies = [
  "hc_zome_rea_unit_rpc",
  "hdk",
  "serde",
+ "vf_attributes_hdk",
 ]
 
 [[package]]

--- a/zomes/rea_unit/zome/Cargo.toml
+++ b/zomes/rea_unit/zome/Cargo.toml
@@ -11,6 +11,7 @@ hdk = "0.0.122"
 
 hc_zome_rea_unit_rpc = { path = "../rpc" }
 hc_zome_rea_unit_lib = { path = "../lib" }
+vf_attributes_hdk = { path = "../../../lib/vf_attributes_hdk" }
 
 [lib]
 path = "src/lib.rs"

--- a/zomes/rea_unit/zome/src/lib.rs
+++ b/zomes/rea_unit/zome/src/lib.rs
@@ -11,11 +11,13 @@ use hdk::prelude::*;
 
 use hc_zome_rea_unit_rpc::*;
 use hc_zome_rea_unit_lib::*;
+use vf_attributes_hdk::UnitInternalAddress;
 
 #[hdk_extern]
 fn entry_defs(_: ()) -> ExternResult<EntryDefsCallbackResult> {
     Ok(EntryDefsCallbackResult::from(vec![
         PathEntry::entry_def(),
+        UnitInternalAddress::entry_def(),
         EntryDef {
             id: UNIT_ENTRY_TYPE.into(),
             visibility: EntryVisibility::Public,


### PR DESCRIPTION
couldn't call `createUnit`