### PR TITLE
Fix `hasUnit` and `createUnit` bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,6 +1229,7 @@ dependencies = [
  "hc_zome_rea_unit_rpc",
  "hdk",
  "serde",
+ "vf_attributes_hdk",
 ]
 
 [[package]]

--- a/lib/hdk_records/src/record_helpers.rs
+++ b/lib/hdk_records/src/record_helpers.rs
@@ -40,6 +40,10 @@ fn get_header_hash(shh: element::SignedHeaderHashed) -> HeaderHash {
 ///
 /// Useful in coordinating updates between different entry types.
 ///
+/// NOTE: this is a very naive recursive algorithm that basically assumes full network
+/// connectivity between everyone at all times, and Updates form a Linked List, rather
+/// than a multi-branching tree. This should be updated during other 'conflict resolution' related
+/// changes outlined in issue https://github.com/holo-rea/holo-rea/issues/196
 pub fn get_latest_header_hash(entry_hash: EntryHash) -> RecordAPIResult<HeaderHash> {
     match get_details(entry_hash, GetOptions { strategy: GetStrategy::Latest })? {
         Some(Details::Entry(details)) => match details.entry_dht_status {

--- a/lib/hdk_records/src/record_helpers.rs
+++ b/lib/hdk_records/src/record_helpers.rs
@@ -45,7 +45,7 @@ pub fn get_latest_header_hash(entry_hash: EntryHash) -> RecordAPIResult<HeaderHa
         Some(Details::Entry(details)) => match details.entry_dht_status {
             metadata::EntryDhtStatus::Live => match details.updates.len() {
                 0 => {
-                    // no updates yet, latest header hash is the first one
+                    // https://docs.rs/hdk/latest/hdk/prelude/struct.EntryDetails.html#structfield.headers
                     Ok(get_header_hash(details.headers.first().unwrap().to_owned()))
                 },
                 _ => {
@@ -53,7 +53,8 @@ pub fn get_latest_header_hash(entry_hash: EntryHash) -> RecordAPIResult<HeaderHa
                     let mut sortlist = details.updates.to_vec();
                     sortlist.sort_by_key(|update| update.header().timestamp().as_micros());
                     let last = sortlist.last().unwrap().to_owned();
-                    Ok(get_header_hash(last))
+                    // recurse (unwrap should be safe because these are Update headers)
+                    get_latest_header_hash(last.header().entry_hash().unwrap().clone())
                 },
             },
             _ => Err(DataIntegrityError::EntryNotFound),

--- a/modules/vf-graphql-holochain/resolvers/measure.ts
+++ b/modules/vf-graphql-holochain/resolvers/measure.ts
@@ -9,6 +9,7 @@ import { DNAIdMappings, DEFAULT_VF_MODULES } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
+  Maybe,
   Measure,
   Unit,
 } from '@valueflows/vf-graphql'
@@ -17,7 +18,10 @@ export default (enabledVFModules: string[] = DEFAULT_VF_MODULES, dnaConfig: DNAI
   const readUnit = mapZomeFn(dnaConfig, conductorUri, 'specification', 'unit', 'get_unit')
 
   return {
-    hasUnit: async (record: Measure): Promise<Unit> => {
+    hasUnit: async (record: Measure): Promise<Maybe<Unit>> => {
+      if (!record.hasUnit) {
+        return null
+      }
       return (await readUnit({ id: record.hasUnit })).unit
     },
   }

--- a/zomes/rea_unit/zome/Cargo.toml
+++ b/zomes/rea_unit/zome/Cargo.toml
@@ -11,6 +11,7 @@ hdk = "0.0.122"
 
 hc_zome_rea_unit_rpc = { path = "../rpc" }
 hc_zome_rea_unit_lib = { path = "../lib" }
+vf_attributes_hdk = { path = "../../../lib/vf_attributes_hdk" }
 
 [lib]
 path = "src/lib.rs"

--- a/zomes/rea_unit/zome/src/lib.rs
+++ b/zomes/rea_unit/zome/src/lib.rs
@@ -11,11 +11,13 @@ use hdk::prelude::*;
 
 use hc_zome_rea_unit_rpc::*;
 use hc_zome_rea_unit_lib::*;
+use vf_attributes_hdk::UnitInternalAddress;
 
 #[hdk_extern]
 fn entry_defs(_: ()) -> ExternResult<EntryDefsCallbackResult> {
     Ok(EntryDefsCallbackResult::from(vec![
         PathEntry::entry_def(),
+        UnitInternalAddress::entry_def(),
         EntryDef {
             id: UNIT_ENTRY_TYPE.into(),
             visibility: EntryVisibility::Public,


### PR DESCRIPTION
Fix graphql request for hasUnit when null
Fix `createUnit` method, which failed because there was a missing Entry Definition

fixes #206 

