### PR TITLE
Add pnpm to nix-shell environment.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -12,5 +12,6 @@ in nixpkgs.mkShell {
     # :TODO: binaryen, wasm-opt?
     # Additional packages go here
     nodejs-16_x
+    nodePackages.pnpm
   ];
 }


### PR DESCRIPTION
Ensure the nix-shell uses its own pnpm instead of any other version in the `$PATH`.