### PR TITLE
fixups in vf-graphql-holochain

### DIFF
--- a/modules/vf-graphql-holochain/mutations/index.ts
+++ b/modules/vf-graphql-holochain/mutations/index.ts
@@ -33,7 +33,7 @@ export type deleteHandler = (root: any, args: { revisionId: string }) => Promise
 export default (enabledVFModules: string[] = DEFAULT_VF_MODULES, dnaConfig: DNAIdMappings, conductorUri: string) => {
   const VFmodules = enabledVFModules || []
   const hasAgent = -1 !== VFmodules.indexOf("agent")
-  const hasMeasurement = -1 !== VFmodules.indexOf("measurement")
+  const hasSpecification = -1 !== VFmodules.indexOf("specification")
   const hasKnowledge = -1 !== VFmodules.indexOf("knowledge")
   const hasObservation = -1 !== VFmodules.indexOf("observation")
   const hasPlanning = -1 !== VFmodules.indexOf("planning")
@@ -41,7 +41,7 @@ export default (enabledVFModules: string[] = DEFAULT_VF_MODULES, dnaConfig: DNAI
   const hasAgreement = -1 !== VFmodules.indexOf("agreement")
 
   return Object.assign(
-    (hasMeasurement ? { ...Unit(dnaConfig, conductorUri) } : {}),
+    (hasSpecification ? { ...Unit(dnaConfig, conductorUri) } : {}),
     (hasKnowledge ? {
       ...ResourceSpecification(dnaConfig, conductorUri),
       ...ProcessSpecification(dnaConfig, conductorUri),

--- a/modules/vf-graphql-holochain/queries/index.ts
+++ b/modules/vf-graphql-holochain/queries/index.ts
@@ -31,7 +31,7 @@ import Agreement from './agreement'
 export default (enabledVFModules: string[] = DEFAULT_VF_MODULES, dnaConfig: DNAIdMappings, conductorUri: string) => {
   const VFmodules = enabledVFModules || []
   const hasAgent = -1 !== VFmodules.indexOf("agent")
-  const hasMeasurement = -1 !== VFmodules.indexOf("measurement")
+  const hasSpecification = -1 !== VFmodules.indexOf("specification")
   const hasKnowledge = -1 !== VFmodules.indexOf("knowledge")
   const hasObservation = -1 !== VFmodules.indexOf("observation")
   const hasPlanning = -1 !== VFmodules.indexOf("planning")
@@ -41,7 +41,7 @@ export default (enabledVFModules: string[] = DEFAULT_VF_MODULES, dnaConfig: DNAI
   return Object.assign({
       ...Action(dnaConfig, conductorUri),
     },
-    (hasMeasurement ? { ...Unit(dnaConfig, conductorUri) } : {}),
+    (hasSpecification ? { ...Unit(dnaConfig, conductorUri) } : {}),
     (hasKnowledge ? {
       ...ResourceSpecification(dnaConfig, conductorUri),
       ...ProcessSpecification(dnaConfig, conductorUri),

--- a/modules/vf-graphql-holochain/resolvers/economicResource.ts
+++ b/modules/vf-graphql-holochain/resolvers/economicResource.ts
@@ -18,7 +18,7 @@ import {
 } from '@valueflows/vf-graphql'
 
 export default (enabledVFModules: string[] = DEFAULT_VF_MODULES, dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const hasMeasurement = -1 !== enabledVFModules.indexOf("measurement")
+  const hasSpecification = -1 !== enabledVFModules.indexOf("specification")
   const hasKnowledge = -1 !== enabledVFModules.indexOf("knowledge")
 
   const readResources = mapZomeFn(dnaConfig, conductorUri, 'observation', 'economic_resource_index', 'query_economic_resources')
@@ -58,7 +58,7 @@ export default (enabledVFModules: string[] = DEFAULT_VF_MODULES, dnaConfig: DNAI
         return (await readAction({ address: record.state }))
       },
     } : {}),
-    (hasMeasurement ? {
+    (hasSpecification ? {
       unitOfEffort: async (record: EconomicResource): Promise<Maybe<Unit>> => {
         if (!record.unitOfEffort) {
           return null

--- a/modules/vf-graphql-holochain/resolvers/index.ts
+++ b/modules/vf-graphql-holochain/resolvers/index.ts
@@ -54,7 +54,7 @@ export default async (options: ResolverOptions) => {
   } = options
 
   const hasAgent = -1 !== enabledVFModules.indexOf("agent")
-  const hasMeasurement = -1 !== enabledVFModules.indexOf("measurement")
+  const hasSpecification = -1 !== enabledVFModules.indexOf("specification")
   const hasKnowledge = -1 !== enabledVFModules.indexOf("knowledge")
   const hasObservation = -1 !== enabledVFModules.indexOf("observation")
   const hasPlanning = -1 !== enabledVFModules.indexOf("planning")
@@ -75,7 +75,7 @@ export default async (options: ResolverOptions) => {
   },
     // object field resolvers
     (hasAgent ? { Agent: Agent(enabledVFModules, dnaConfig, conductorUri) } : {}),
-    (hasMeasurement ? { Measure: Measure(enabledVFModules, dnaConfig, conductorUri) } : {}),
+    (hasSpecification ? { Measure: Measure(enabledVFModules, dnaConfig, conductorUri) } : {}),
     (hasKnowledge ? { ResourceSpecification: ResourceSpecification(enabledVFModules, dnaConfig, conductorUri) } : {}),
     (hasObservation ? {
       Process: Process(enabledVFModules, dnaConfig, conductorUri),

--- a/modules/vf-graphql-holochain/resolvers/resourceSpecification.ts
+++ b/modules/vf-graphql-holochain/resolvers/resourceSpecification.ts
@@ -16,7 +16,7 @@ import {
 } from '@valueflows/vf-graphql'
 
 export default (enabledVFModules: string[] = DEFAULT_VF_MODULES, dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const hasMeasurement = -1 !== enabledVFModules.indexOf("measurement")
+  const hasSpecification = -1 !== enabledVFModules.indexOf("specification")
   const hasObservation = -1 !== enabledVFModules.indexOf("observation")
 
   const queryResources = mapZomeFn(dnaConfig, conductorUri, 'observation', 'economic_resource_index', 'query_economic_resources')
@@ -28,7 +28,7 @@ export default (enabledVFModules: string[] = DEFAULT_VF_MODULES, dnaConfig: DNAI
         return await queryResources({ params: { conformsTo: record.id } })
       },
     } : {}),
-    (hasMeasurement ? {
+    (hasSpecification ? {
       defaultUnitOfEffort: async (record: ResourceSpecification): Promise<Maybe<Unit>> => {
         if (!record.defaultUnitOfEffort) {
           return null

--- a/modules/vf-graphql-holochain/types.ts
+++ b/modules/vf-graphql-holochain/types.ts
@@ -84,10 +84,12 @@ export function injectTypename<T> (name: string, fn: Resolver<T>): Resolver<T> {
 // default 'full suite' VF module set supported by Holo-REA
 
 export const DEFAULT_VF_MODULES = [
-  'knowledge', 'measurement',
   'agent',
-  'observation', 'planning',
-  'proposal', 'agreement',
+  'agreement',
+  'observation',
+  'planning',
+  'proposal',
+  'specification',
 ]
 
 // scalar types

--- a/modules/vf-graphql-holochain/types.ts
+++ b/modules/vf-graphql-holochain/types.ts
@@ -17,11 +17,12 @@ import { Kind } from 'graphql/language'
 // Configuration object to allow specifying custom conductor DNA IDs to bind to.
 // Default is to use a DNA with the same ID as the mapping ID (ie. agent = "agent")
 export interface DNAIdMappings {
-  agent: CellId,
-  observation: CellId,
-  planning: CellId,
-  proposal: CellId,
-  specification: CellId,
+  agent?: CellId,
+  agreement?: CellId,
+  observation?: CellId,
+  planning?: CellId,
+  proposal?: CellId,
+  specification?: CellId,
 }
 
 export { CellId }


### PR DESCRIPTION
`agreement` was missing from `DNAIdMappings`

also each one seems to be optional, since it depends on the configuration

- [x] There are some outdated references to `hasMeasurement` in the vf-graphq-holochain module that need to be replaced with `hasSpecification`