### PR TITLE
#255 test satisfaction rust compilation and Runtime error fixes

### DIFF
--- a/test/satisfaction/satisfaction_records_e2e.js
+++ b/test/satisfaction/satisfaction_records_e2e.js
@@ -65,6 +65,8 @@ runner.registerScenario('satisfactions can be written and read between DNAs by a
   // ASSERT: check event field refs
   readResponse = await observation.call('economic_event', 'get_economic_event', { address: eventId })
   // TESTS start to fail here, and continue to the end of the file
+  // The zome calls themselves are not failing, it is that
+  // the response data does not match the assertions
   /*
   not ok 8 EconomicEvent.satisfies value present
   ---

--- a/test/satisfaction/satisfaction_records_e2e.js
+++ b/test/satisfaction/satisfaction_records_e2e.js
@@ -64,6 +64,14 @@ runner.registerScenario('satisfactions can be written and read between DNAs by a
 
   // ASSERT: check event field refs
   readResponse = await observation.call('economic_event', 'get_economic_event', { address: eventId })
+  // TESTS start to fail here, and continue to the end of the file
+  /*
+  not ok 8 EconomicEvent.satisfies value present
+  ---
+    operator: ok
+    expected: true
+    actual:   undefined
+  */
   t.ok(readResponse.economicEvent.satisfies, 'EconomicEvent.satisfies value present')
   t.equal(readResponse.economicEvent.satisfies.length, 1, 'EconomicEvent.satisfies reference saved')
   t.deepEqual(readResponse.economicEvent.satisfies[0], satisfactionId, 'EconomicEvent.satisfies reference OK')

--- a/zomes/rea_satisfaction/lib_destination/src/lib.rs
+++ b/zomes/rea_satisfaction/lib_destination/src/lib.rs
@@ -26,6 +26,9 @@ use hc_zome_rea_satisfaction_storage::*;
 use hc_zome_rea_satisfaction_rpc::*;
 use hc_zome_rea_satisfaction_lib::construct_response;
 
+// :SHONK: needed to re-export for zome `entry_defs()` where macro-assigned defs are overridden
+pub use hdk_records::CAP_STORAGE_ENTRY_DEF_ID;
+
 pub fn handle_create_satisfaction<S>(entry_def_id: S, satisfaction: CreateRequest) -> RecordAPIResult<ResponseData>
     where S: AsRef<str>
 {

--- a/zomes/rea_satisfaction/lib_origin/src/lib.rs
+++ b/zomes/rea_satisfaction/lib_origin/src/lib.rs
@@ -30,6 +30,9 @@ use hc_zome_rea_satisfaction_storage::*;
 use hc_zome_rea_satisfaction_rpc::*;
 use hc_zome_rea_satisfaction_lib::construct_response;
 
+// :SHONK: needed to re-export for zome `entry_defs()` where macro-assigned defs are overridden
+pub use hdk_records::CAP_STORAGE_ENTRY_DEF_ID;
+
 pub fn handle_create_satisfaction<S>(entry_def_id: S, satisfaction: CreateRequest) -> RecordAPIResult<ResponseData>
     where S: AsRef<str>
 {
@@ -46,10 +49,12 @@ pub fn handle_create_satisfaction<S>(entry_def_id: S, satisfaction: CreateReques
     } else {
         // links to remote event, ping associated foreign DNA & fail if there's an error
         // :TODO: consider the implications of this in loosely coordinated multi-network spaces
-        call_zome_method(
-            event_or_commitment,
-            &REPLICATE_CREATE_API_METHOD,
-            CreateParams { satisfaction: satisfaction.to_owned() },
+        // we assign a type to the response so that call_zome_method can
+        // effectively deserialize the response without failing
+        let _result: ResponseData = call_zome_method(
+          event_or_commitment,
+          &REPLICATE_CREATE_API_METHOD,
+          CreateParams { satisfaction: satisfaction.to_owned() },
         )?;
     }
 

--- a/zomes/rea_satisfaction/zome_observation/src/lib.rs
+++ b/zomes/rea_satisfaction/zome_observation/src/lib.rs
@@ -21,28 +21,43 @@ fn entry_defs(_: ()) -> ExternResult<EntryDefsCallbackResult> {
         PathEntry::entry_def(),
         SatisfactionAddress::entry_def(),
         EntryDef {
+            id: CAP_STORAGE_ENTRY_DEF_ID.into(),
+            visibility: EntryVisibility::Private,
+            crdt_type: CrdtType,
+            required_validations: 1.into(),
+            required_validation_type: RequiredValidationType::default(),
+        },
+        EntryDef {
             id: SATISFACTION_ENTRY_TYPE.into(),
             visibility: EntryVisibility::Public,
             crdt_type: CrdtType,
             required_validations: 1.into(),
             required_validation_type: RequiredValidationType::default(),
-        }
+        },
     ]))
 }
 
 #[hdk_extern]
 fn satisfaction_created(CreateParams { satisfaction }: CreateParams) -> ExternResult<ResponseData> {
-    Ok(handle_create_satisfaction(SATISFACTION_ENTRY_TYPE, satisfaction)?)
+    Ok(handle_create_satisfaction(
+        SATISFACTION_ENTRY_TYPE,
+        satisfaction,
+    )?)
 }
 
 #[hdk_extern]
-fn get_satisfaction(ByAddress { address }: ByAddress<SatisfactionAddress>) -> ExternResult<ResponseData> {
+fn get_satisfaction(
+    ByAddress { address }: ByAddress<SatisfactionAddress>,
+) -> ExternResult<ResponseData> {
     Ok(handle_get_satisfaction(SATISFACTION_ENTRY_TYPE, address)?)
 }
 
 #[hdk_extern]
 fn satisfaction_updated(UpdateParams { satisfaction }: UpdateParams) -> ExternResult<ResponseData> {
-    Ok(handle_update_satisfaction(SATISFACTION_ENTRY_TYPE, satisfaction)?)
+    Ok(handle_update_satisfaction(
+        SATISFACTION_ENTRY_TYPE,
+        satisfaction,
+    )?)
 }
 
 #[hdk_extern]

--- a/zomes/rea_satisfaction/zome_planning/src/lib.rs
+++ b/zomes/rea_satisfaction/zome_planning/src/lib.rs
@@ -19,28 +19,43 @@ fn entry_defs(_: ()) -> ExternResult<EntryDefsCallbackResult> {
         PathEntry::entry_def(),
         SatisfactionAddress::entry_def(),
         EntryDef {
+            id: CAP_STORAGE_ENTRY_DEF_ID.into(),
+            visibility: EntryVisibility::Private,
+            crdt_type: CrdtType,
+            required_validations: 1.into(),
+            required_validation_type: RequiredValidationType::default(),
+        },
+        EntryDef {
             id: SATISFACTION_ENTRY_TYPE.into(),
             visibility: EntryVisibility::Public,
             crdt_type: CrdtType,
             required_validations: 1.into(),
             required_validation_type: RequiredValidationType::default(),
-        }
+        },
     ]))
 }
 
 #[hdk_extern]
 fn create_satisfaction(CreateParams { satisfaction }: CreateParams) -> ExternResult<ResponseData> {
-    Ok(handle_create_satisfaction(SATISFACTION_ENTRY_TYPE, satisfaction)?)
+    Ok(handle_create_satisfaction(
+        SATISFACTION_ENTRY_TYPE,
+        satisfaction,
+    )?)
 }
 
 #[hdk_extern]
-fn get_satisfaction(ByAddress { address }: ByAddress<SatisfactionAddress>) -> ExternResult<ResponseData> {
+fn get_satisfaction(
+    ByAddress { address }: ByAddress<SatisfactionAddress>,
+) -> ExternResult<ResponseData> {
     Ok(handle_get_satisfaction(SATISFACTION_ENTRY_TYPE, address)?)
 }
 
 #[hdk_extern]
 fn update_satisfaction(UpdateParams { satisfaction }: UpdateParams) -> ExternResult<ResponseData> {
-    Ok(handle_update_satisfaction(SATISFACTION_ENTRY_TYPE, satisfaction)?)
+    Ok(handle_update_satisfaction(
+        SATISFACTION_ENTRY_TYPE,
+        satisfaction,
+    )?)
 }
 
 #[hdk_extern]


### PR DESCRIPTION
```
cd test
WASM_LOG=debug RUST_LOG="debug,wasmer_compiler_cranelift=error,holochain::core::workflow=error,holochain::conductor::handle=error,holochain::conductor::entry_def_store=error,holochain_p2p::spawn::actor=error" RUST_BACKTRACE=1 npx tape satisfaction/**/*.js
```

working on
relates #255 

Important:
what I sense about this is that it's gotten past compilation and "Rust" issues, and is now down to hREA implementation and configuration issues. The zome functions are being called successfully, but the assertions about what data should be in the responses are wrong. 
Specifically, `satisfies` appears to be a 0 length vec/array when it have data in it, at least an ID


before, 2 out of an unkown number were passing

after, 7 out of an unknown total number are passing
```
# tests 9
# pass  7
# fail  2
```