### PR TITLE
#254 test/flows fix the initial errors by using mockIdentifier()

### DIFF
--- a/test/flows/flow_records_graphql.js
+++ b/test/flows/flow_records_graphql.js
@@ -4,6 +4,7 @@ const {
   buildRunner,
   buildPlayer,
   mockAgentId,
+  mockIdentifier,
 } = require('../init')
 
 const runner = buildRunner()
@@ -86,7 +87,7 @@ runner.registerScenario('flow records and relationships', async (s, t) => {
       "provider": tempProviderAgentId,
       "receiver": tempReceiverAgentId,
       "due": "2019-11-19T04:29:55.056Z",
-      "resourceQuantity": { hasNumericalValue: 1, hasUnit: "todo-some-unit-id" },
+      "resourceQuantity": { hasNumericalValue: 1, hasUnit: mockIdentifier() },
       "resourceClassifiedAs": ["some-resource-type"],
       "note": "some input will be provided"
     },
@@ -96,7 +97,7 @@ runner.registerScenario('flow records and relationships', async (s, t) => {
       "provider": tempProviderAgentId,
       "receiver": tempReceiverAgentId,
       "hasPointInTime": "2019-11-19T04:27:55.056Z",
-      "resourceQuantity": { hasNumericalValue: 1, hasUnit: "todo-some-unit-id" },
+      "resourceQuantity": { hasNumericalValue: 1, hasUnit: mockIdentifier() },
       "resourceClassifiedAs": ["some-resource-type"],
       "note": "some input was used up"
     },
@@ -112,7 +113,7 @@ runner.registerScenario('flow records and relationships', async (s, t) => {
       "provider": tempProviderAgentId,
       "receiver": tempReceiverAgentId,
       "due": "2019-11-19T04:29:55.056Z",
-      "resourceQuantity": { hasNumericalValue: 1, hasUnit: "todo-some-unit-id" },
+      "resourceQuantity": { hasNumericalValue: 1, hasUnit: mockIdentifier() },
       "resourceClassifiedAs": ["some-resource-type"],
       "note": "I'll make the thing happen"
     },
@@ -122,7 +123,7 @@ runner.registerScenario('flow records and relationships', async (s, t) => {
       "provider": tempProviderAgentId,
       "receiver": tempReceiverAgentId,
       "hasPointInTime": "2019-11-19T04:27:55.056Z",
-      "resourceQuantity": { hasNumericalValue: 1, hasUnit: "todo-some-unit-id" },
+      "resourceQuantity": { hasNumericalValue: 1, hasUnit: mockIdentifier() },
       "resourceClassifiedAs": ["some-resource-type"],
       "note": "hooray, the thing happened!"
     },


### PR DESCRIPTION
improves on #254 situation

this gets us to the place where it seems to be hrea logic/configuration/expectations that are breaking down, not code. 


I did a bunch of digging, but had a real hard time wrapping my head around the interlinking of the indexes between the planning DNA and the observation DNA. 

