### PR TITLE
useful stack trace shim for outdated tryorama

### DIFF
--- a/scripts/fixTryoramaTimeout.js
+++ b/scripts/fixTryoramaTimeout.js
@@ -19,3 +19,23 @@ fs.writeFileSync(filePath, contents.replace(
 ))
 
 console.log('Tryorama websocket timeout patched successfully!')
+
+/*
+Stack trace shim
+*/
+
+const tryoramaMiddlewareFilePath = path.resolve(__dirname, '../node_modules/.pnpm/@holochain+tryorama@0.4.10/node_modules/@holochain/tryorama/lib/middleware.js')
+
+if (!fs.existsSync(tryoramaMiddlewareFilePath)) {
+  console.error('Unable to find Tryorama middleware file for patching. Was it updated? Is this script still needed?')
+  process.exit(1)
+}
+
+const tryoramaMiddlewareContents = fs.readFileSync(tryoramaMiddlewareFilePath) + ''
+
+fs.writeFileSync(tryoramaMiddlewareFilePath, tryoramaMiddlewareContents.replace(
+  't.fail("Test threw an exception. See output for details.")',
+  't.fail(repr)',
+))
+
+console.log('Tryorama middleware stack trace replaced successfully!')


### PR DESCRIPTION
fixes #271 

after applying this, I now get, which includes the useful stack trace:
```
x


  ---
    operator: fail
    at: <anonymous> (/Users/connor/code/hrea/node_modules/.pnpm/@holochain+tryorama@0.4.10/node_modules/@holochain/tryorama/src/middleware.ts:137:13)
    stack: |-
           Error: TypeError: Cannot read properties of null (reading 'satisfies')
             at /Users/connor/code/hrea/test/flows/flow_records_graphql.js:352:25
             at processTicksAndRejections (node:internal/process/task_queues:96:5)
             at p (/Users/connor/code/hrea/node_modules/.pnpm/@holochain+tryorama@0.4.10/node_modules/@holochain/tryorama/src/middleware.ts:126:29)
             at Test.assert [as _assert] (/Users/connor/code/hrea/node_modules/.pnpm/tape@4.15.0/node_modules/tape/lib/test.js:275:54)
             at Test.bound [as _assert] (/Users/connor/code/hrea/node_modules/.pnpm/tape@4.15.0/node_modules/tape/lib/test.js:89:32)
             at Test.fail (/Users/connor/code/hrea/node_modules/.pnpm/tape@4.15.0/node_modules/tape/lib/test.js:368:10)
             at Test.bound [as fail] (/Users/connor/code/hrea/node_modules/.pnpm/tape@4.15.0/node_modules/tape/lib/test.js:89:32)
             at /Users/connor/code/hrea/node_modules/.pnpm/@holochain+tryorama@0.4.10/node_modules/@holochain/tryorama/src/middleware.ts:137:13
             at processTicksAndRejections (node:internal/process/task_queues:96:5)

  ...



  1 tests
  41 passed
  1 failed

  Failed Tests:   There was 1 failure

    x TypeError: Cannot read properties of null (reading 'satisfies') at /Users/connor/code/hrea/test/flows/flow_records_graphql.js:352:25 at processTicksAndRejections (node:internal/process/task_queues:96:5) at p (/Users/connor/code/hrea/node_modules/.pnpm/@holochain+tryorama@0.4.10/node_modules/@holochain/tryorama/src/middleware.ts:126:29)
```
