### PR TITLE
Map zome generic params

### DIFF
--- a/lib/hdk_semantic_indexes/rpc/src/lib.rs
+++ b/lib/hdk_semantic_indexes/rpc/src/lib.rs
@@ -20,6 +20,11 @@ pub struct ByHeader {
     pub address: HeaderHash,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ByRevision {
+    pub revision_id: HeaderHash,
+}
 /// Shared parameter struct that all related record storage endpoints must implement
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ByAddress<T> {

--- a/lib/vf_attributes_hdk/src/lib.rs
+++ b/lib/vf_attributes_hdk/src/lib.rs
@@ -5,7 +5,7 @@ pub use chrono::{ FixedOffset, Utc, DateTime };
 pub use holo_hash::{ AgentPubKey, EntryHash, HeaderHash };
 pub use holochain_zome_types::timestamp::Timestamp;
 pub use hdk_uuid_types::{DnaAddressable};
-pub use hdk_semantic_indexes_zome_rpc::{ByHeader, ByAddress};
+pub use hdk_semantic_indexes_zome_rpc::{ByHeader, ByAddress, ByRevision};
 
 simple_alias!(ActionId => String);
 

--- a/modules/vf-graphql-holochain/connection.ts
+++ b/modules/vf-graphql-holochain/connection.ts
@@ -264,12 +264,12 @@ const encodeFields = (args: any): any => {
 //----------------------------------------------------------------------------------------------------------------------
 
 // explicit type-loss at the boundary
-export type BoundZomeFn = (args: any) => any;
+export type BoundZomeFn<InputType, OutputType> = (args: InputType) => OutputType;
 
 /**
  * Higher-order function to generate async functions for calling zome RPC methods
  */
-const zomeFunction = (socketURI: string, cell_id: CellId, zome_name: string, fn_name: string, skipEncodeDecode?: boolean): BoundZomeFn => async (args) => {
+const zomeFunction = <InputType, OutputType>(socketURI: string, cell_id: CellId, zome_name: string, fn_name: string, skipEncodeDecode?: boolean): BoundZomeFn<InputType, Promise<OutputType>> => async (args): Promise<OutputType> => {
   const { callZome } = await getConnection(socketURI)
   const res = await callZome({
     cap_secret: null, // :TODO:
@@ -292,8 +292,8 @@ const zomeFunction = (socketURI: string, cell_id: CellId, zome_name: string, fn_
  *
  * @return bound async zome function which can be called directly
  */
-export const mapZomeFn = (mappings: DNAIdMappings, socketURI: string, instance: string, zome: string, fn: string, skipEncodeDecode?: boolean) =>
-  zomeFunction(socketURI, (mappings && mappings[instance]), zome, fn, skipEncodeDecode)
+export const mapZomeFn = <InputType, OutputType>(mappings: DNAIdMappings, socketURI: string, instance: string, zome: string, fn: string, skipEncodeDecode?: boolean) =>
+  zomeFunction<InputType, OutputType>(socketURI, (mappings && mappings[instance]), zome, fn, skipEncodeDecode)
 
 
 export const extractEdges = <T>(withEdges: { edges: { node: T }[] }): T[] => {

--- a/modules/vf-graphql-holochain/mutations/agreement.ts
+++ b/modules/vf-graphql-holochain/mutations/agreement.ts
@@ -5,7 +5,7 @@
  * @since:   2020-06-19
  */
 
-import { DNAIdMappings } from '../types'
+import { ByRevision, DNAIdMappings } from '../types'
 import { mapZomeFn } from '../connection'
 import { deleteHandler } from './'
 
@@ -26,9 +26,9 @@ export interface UpdateArgs {
 export type updateHandler = (root: any, args: UpdateArgs) => Promise<AgreementResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const runCreate = mapZomeFn(dnaConfig, conductorUri, 'agreement', 'agreement', 'create_agreement')
-  const runUpdate = mapZomeFn(dnaConfig, conductorUri, 'agreement', 'agreement', 'update_agreement')
-  const runDelete = mapZomeFn(dnaConfig, conductorUri, 'agreement', 'agreement', 'delete_agreement')
+  const runCreate = mapZomeFn<CreateArgs, AgreementResponse>(dnaConfig, conductorUri, 'agreement', 'agreement', 'create_agreement')
+  const runUpdate = mapZomeFn<UpdateArgs, AgreementResponse>(dnaConfig, conductorUri, 'agreement', 'agreement', 'update_agreement')
+  const runDelete = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'agreement', 'agreement', 'delete_agreement')
 
   const createAgreement: createHandler = async (root, args) => {
     // :SHONK: Inject current time as `created` if not present.
@@ -43,8 +43,8 @@ export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
     return runUpdate(args)
   }
 
-  const deleteAgreement: deleteHandler = async (root, { revisionId }) => {
-    return runDelete({ address: revisionId })
+  const deleteAgreement: deleteHandler = async (root, args) => {
+    return runDelete(args)
   }
 
   return {

--- a/modules/vf-graphql-holochain/mutations/commitment.ts
+++ b/modules/vf-graphql-holochain/mutations/commitment.ts
@@ -5,7 +5,7 @@
  * @since:   2019-08-28
  */
 
-import { DNAIdMappings } from '../types'
+import { ByRevision, DNAIdMappings } from '../types'
 import { mapZomeFn } from '../connection'
 import { deleteHandler } from './'
 
@@ -26,9 +26,9 @@ export interface UpdateArgs {
 export type updateHandler = (root: any, args: UpdateArgs) => Promise<CommitmentResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const runCreate = mapZomeFn(dnaConfig, conductorUri, 'planning', 'commitment', 'create_commitment')
-  const runUpdate = mapZomeFn(dnaConfig, conductorUri, 'planning', 'commitment', 'update_commitment')
-  const runDelete = mapZomeFn(dnaConfig, conductorUri, 'planning', 'commitment', 'delete_commitment')
+  const runCreate = mapZomeFn<CreateArgs, CommitmentResponse>(dnaConfig, conductorUri, 'planning', 'commitment', 'create_commitment')
+  const runUpdate = mapZomeFn<UpdateArgs, CommitmentResponse>(dnaConfig, conductorUri, 'planning', 'commitment', 'update_commitment')
+  const runDelete = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'planning', 'commitment', 'delete_commitment')
 
   const createCommitment: createHandler = async (root, args) => {
     return runCreate(args)
@@ -39,7 +39,7 @@ export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
   }
 
   const deleteCommitment: deleteHandler = async (root, args) => {
-    return runDelete({ address: args.revisionId })
+    return runDelete(args)
   }
 
   return {

--- a/modules/vf-graphql-holochain/mutations/economicEvent.ts
+++ b/modules/vf-graphql-holochain/mutations/economicEvent.ts
@@ -15,6 +15,7 @@ import {
   EconomicEventUpdateParams,
   EconomicEventResponse,
 } from '@valueflows/vf-graphql'
+import { HeaderHash } from '@holochain/client'
 
 export interface CreateArgs {
   event: EconomicEventCreateParams,
@@ -25,12 +26,16 @@ export type createHandler = (root: any, args: CreateArgs) => Promise<EconomicEve
 export interface UpdateArgs {
   event: EconomicEventUpdateParams,
 }
+
+export interface DeleteArgs {
+  revisionId: string,
+}
 export type updateHandler = (root: any, args: UpdateArgs) => Promise<EconomicEventResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const runCreate = mapZomeFn(dnaConfig, conductorUri, 'observation', 'economic_event', 'create_economic_event')
-  const runUpdate = mapZomeFn(dnaConfig, conductorUri, 'observation', 'economic_event', 'update_economic_event')
-  const runDelete = mapZomeFn(dnaConfig, conductorUri, 'observation', 'economic_event', 'delete_economic_event')
+  const runCreate = mapZomeFn<CreateArgs, EconomicEventResponse>(dnaConfig, conductorUri, 'observation', 'economic_event', 'create_economic_event')
+  const runUpdate = mapZomeFn<UpdateArgs, EconomicEventResponse>(dnaConfig, conductorUri, 'observation', 'economic_event', 'update_economic_event')
+  const runDelete = mapZomeFn<DeleteArgs, boolean>(dnaConfig, conductorUri, 'observation', 'economic_event', 'delete_economic_event')
 
   const createEconomicEvent: createHandler = async (root, args) => {
     return runCreate(args)

--- a/modules/vf-graphql-holochain/mutations/economicEvent.ts
+++ b/modules/vf-graphql-holochain/mutations/economicEvent.ts
@@ -5,7 +5,7 @@
  * @since:   2019-05-27
  */
 
-import { DNAIdMappings } from '../types'
+import { ByRevision, DNAIdMappings } from '../types'
 import { mapZomeFn } from '../connection'
 import { deleteHandler } from './'
 
@@ -27,15 +27,12 @@ export interface UpdateArgs {
   event: EconomicEventUpdateParams,
 }
 
-export interface DeleteArgs {
-  revisionId: string,
-}
 export type updateHandler = (root: any, args: UpdateArgs) => Promise<EconomicEventResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
   const runCreate = mapZomeFn<CreateArgs, EconomicEventResponse>(dnaConfig, conductorUri, 'observation', 'economic_event', 'create_economic_event')
   const runUpdate = mapZomeFn<UpdateArgs, EconomicEventResponse>(dnaConfig, conductorUri, 'observation', 'economic_event', 'update_economic_event')
-  const runDelete = mapZomeFn<DeleteArgs, boolean>(dnaConfig, conductorUri, 'observation', 'economic_event', 'delete_economic_event')
+  const runDelete = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'observation', 'economic_event', 'delete_economic_event')
 
   const createEconomicEvent: createHandler = async (root, args) => {
     return runCreate(args)

--- a/modules/vf-graphql-holochain/mutations/economicResource.ts
+++ b/modules/vf-graphql-holochain/mutations/economicResource.ts
@@ -19,7 +19,7 @@ export interface UpdateArgs {
 export type updateHandler = (root: any, args: UpdateArgs) => Promise<EconomicResourceResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const runUpdate = mapZomeFn(dnaConfig, conductorUri, 'observation', 'economic_resource', 'update_economic_resource')
+  const runUpdate = mapZomeFn<UpdateArgs, EconomicResourceResponse>(dnaConfig, conductorUri, 'observation', 'economic_resource', 'update_economic_resource')
 
   const updateEconomicResource: updateHandler = async (root, args) => {
     return runUpdate(args)

--- a/modules/vf-graphql-holochain/mutations/fulfillment.ts
+++ b/modules/vf-graphql-holochain/mutations/fulfillment.ts
@@ -5,7 +5,7 @@
  * @since:   2019-08-28
  */
 
-import { DNAIdMappings } from '../types'
+import { ByRevision, DNAIdMappings } from '../types'
 import { mapZomeFn } from '../connection'
 import { deleteHandler } from './'
 
@@ -26,9 +26,9 @@ export interface UpdateArgs {
 export type updateHandler = (root: any, args: UpdateArgs) => Promise<FulfillmentResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const runCreate = mapZomeFn(dnaConfig, conductorUri, 'planning', 'fulfillment', 'create_fulfillment')
-  const runUpdate = mapZomeFn(dnaConfig, conductorUri, 'planning', 'fulfillment', 'update_fulfillment')
-  const runDelete = mapZomeFn(dnaConfig, conductorUri, 'planning', 'fulfillment', 'delete_fulfillment')
+  const runCreate = mapZomeFn<CreateArgs, FulfillmentResponse>(dnaConfig, conductorUri, 'planning', 'fulfillment', 'create_fulfillment')
+  const runUpdate = mapZomeFn<UpdateArgs, FulfillmentResponse>(dnaConfig, conductorUri, 'planning', 'fulfillment', 'update_fulfillment')
+  const runDelete = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'planning', 'fulfillment', 'delete_fulfillment')
 
   const createFulfillment: createHandler = async (root, args) => {
     return runCreate(args)
@@ -39,7 +39,7 @@ export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
   }
 
   const deleteFulfillment: deleteHandler = async (root, args) => {
-    return runDelete({ address: args.revisionId })
+    return runDelete(args)
   }
 
   return {

--- a/modules/vf-graphql-holochain/mutations/index.ts
+++ b/modules/vf-graphql-holochain/mutations/index.ts
@@ -5,7 +5,7 @@
  * @since:   2019-05-22
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ByRevision } from '../types'
 
 import ResourceSpecification from './resourceSpecification'
 import ProcessSpecification from './processSpecification'
@@ -29,7 +29,7 @@ import Agreement from './agreement'
 import Plan from './plan'
 
 // generic deletion calling format used by all mutations
-export type deleteHandler = (root: any, args: { revisionId: string }) => Promise<boolean>
+export type deleteHandler = (root: any, args: ByRevision) => Promise<boolean>
 
 export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DNAIdMappings, conductorUri: string) => {
   const hasMeasurement = -1 !== enabledVFModules.indexOf(VfModule.Measurement)

--- a/modules/vf-graphql-holochain/mutations/intent.ts
+++ b/modules/vf-graphql-holochain/mutations/intent.ts
@@ -5,7 +5,7 @@
  * @since:   2019-08-31
  */
 
-import { DNAIdMappings } from '../types'
+import { ByRevision, DNAIdMappings } from '../types'
 import { mapZomeFn } from '../connection'
 import { deleteHandler } from './'
 
@@ -26,9 +26,9 @@ export interface UpdateArgs {
 export type updateHandler = (root: any, args: UpdateArgs) => Promise<IntentResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const runCreate = mapZomeFn(dnaConfig, conductorUri, 'planning', 'intent', 'create_intent')
-  const runUpdate = mapZomeFn(dnaConfig, conductorUri, 'planning', 'intent', 'update_intent')
-  const runDelete = mapZomeFn(dnaConfig, conductorUri, 'planning', 'intent', 'delete_intent')
+  const runCreate = mapZomeFn<CreateArgs, IntentResponse>(dnaConfig, conductorUri, 'planning', 'intent', 'create_intent')
+  const runUpdate = mapZomeFn<UpdateArgs, IntentResponse>(dnaConfig, conductorUri, 'planning', 'intent', 'update_intent')
+  const runDelete = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'planning', 'intent', 'delete_intent')
 
   const createIntent: createHandler = async (root, args) => {
     return runCreate(args)
@@ -39,7 +39,7 @@ export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
   }
 
   const deleteIntent: deleteHandler = async (root, args) => {
-    return runDelete({ address: args.revisionId })
+    return runDelete(args)
   }
 
   return {

--- a/modules/vf-graphql-holochain/mutations/plan.ts
+++ b/modules/vf-graphql-holochain/mutations/plan.ts
@@ -5,7 +5,7 @@
  * @since:   2022-05-23
  */
 
-import { DNAIdMappings } from '../types'
+import { ByRevision, DNAIdMappings } from '../types'
 import { mapZomeFn } from '../connection'
 import { deleteHandler } from './'
 
@@ -26,9 +26,9 @@ export interface UpdateArgs {
 export type updateHandler = (root: any, args: UpdateArgs) => Promise<PlanResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const runCreate = mapZomeFn(dnaConfig, conductorUri, 'plan', 'plan', 'create_plan')
-  const runUpdate = mapZomeFn(dnaConfig, conductorUri, 'plan', 'plan', 'update_plan')
-  const runDelete = mapZomeFn(dnaConfig, conductorUri, 'plan', 'plan', 'delete_plan')
+  const runCreate = mapZomeFn<CreateArgs, PlanResponse>(dnaConfig, conductorUri, 'plan', 'plan', 'create_plan')
+  const runUpdate = mapZomeFn<UpdateArgs, PlanResponse>(dnaConfig, conductorUri, 'plan', 'plan', 'update_plan')
+  const runDelete = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'plan', 'plan', 'delete_plan')
 
   const createPlan: createHandler = async (root, args) => {
     return runCreate(args)
@@ -38,8 +38,8 @@ export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
     return runUpdate(args)
   }
 
-  const deletePlan: deleteHandler = async (root, { revisionId }) => {
-    return runDelete({ address: revisionId })
+  const deletePlan: deleteHandler = async (root, args) => {
+    return runDelete(args)
   }
 
   return {

--- a/modules/vf-graphql-holochain/mutations/process.ts
+++ b/modules/vf-graphql-holochain/mutations/process.ts
@@ -5,7 +5,7 @@
  * @since:   2019-09-12
  */
 
-import { DNAIdMappings } from '../types'
+import { ByRevision, DNAIdMappings } from '../types'
 import { mapZomeFn } from '../connection'
 import { deleteHandler } from './'
 
@@ -26,9 +26,9 @@ export interface UpdateArgs {
 export type updateHandler = (root: any, args: UpdateArgs) => Promise<ProcessResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const createHandler = mapZomeFn(dnaConfig, conductorUri, 'observation', 'process', 'create_process')
-  const updateHandler = mapZomeFn(dnaConfig, conductorUri, 'observation', 'process', 'update_process')
-  const deleteHandler = mapZomeFn(dnaConfig, conductorUri, 'observation', 'process', 'delete_process')
+  const createHandler = mapZomeFn<CreateArgs, ProcessResponse>(dnaConfig, conductorUri, 'observation', 'process', 'create_process')
+  const updateHandler = mapZomeFn<UpdateArgs, ProcessResponse>(dnaConfig, conductorUri, 'observation', 'process', 'update_process')
+  const deleteHandler = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'observation', 'process', 'delete_process')
 
   const createProcess: createHandler = async (root, args) => {
     return createHandler(args)
@@ -39,7 +39,7 @@ export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
   }
 
   const deleteProcess: deleteHandler = async (root, args) => {
-    return deleteHandler({ address: args.revisionId })
+    return deleteHandler(args)
   }
 
   return {

--- a/modules/vf-graphql-holochain/mutations/processSpecification.ts
+++ b/modules/vf-graphql-holochain/mutations/processSpecification.ts
@@ -5,7 +5,7 @@
  * @since:   2019-09-12
  */
 
-import { DNAIdMappings } from '../types'
+import { ByRevision, DNAIdMappings } from '../types'
 import { mapZomeFn } from '../connection'
 import { deleteHandler } from './'
 
@@ -26,24 +26,20 @@ export interface UpdateArgs {
 export type updateHandler = (root: any, args: UpdateArgs) => Promise<ProcessSpecificationResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const runCreate = mapZomeFn(dnaConfig, conductorUri, 'specification', 'process_specification', 'create_process_specification')
-  const runUpdate = mapZomeFn(dnaConfig, conductorUri, 'specification', 'process_specification', 'update_process_specification')
-  const runDelete = mapZomeFn(dnaConfig, conductorUri, 'specification', 'process_specification', 'delete_process_specification')
+  const runCreate = mapZomeFn<CreateArgs, ProcessSpecificationResponse>(dnaConfig, conductorUri, 'specification', 'process_specification', 'create_process_specification')
+  const runUpdate = mapZomeFn<UpdateArgs, ProcessSpecificationResponse>(dnaConfig, conductorUri, 'specification', 'process_specification', 'update_process_specification')
+  const runDelete = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'specification', 'process_specification', 'delete_process_specification')
 
   const createProcessSpecification: createHandler = async (root, args) => {
-    return runCreate({
-      process_specification: args.processSpecification
-    })
+    return runCreate(args)
   }
 
   const updateProcessSpecification: updateHandler = async (root, args) => {
-    return runUpdate({
-      process_specification: args.processSpecification
-    })
+    return runUpdate(args)
   }
 
   const deleteProcessSpecification: deleteHandler = async (root, args) => {
-    return runDelete({ address: args.revisionId })
+    return runDelete(args)
   }
 
   return {

--- a/modules/vf-graphql-holochain/mutations/proposal.ts
+++ b/modules/vf-graphql-holochain/mutations/proposal.ts
@@ -5,7 +5,7 @@
  * @since:   2019-09-12
  */
 
-import { DNAIdMappings } from '../types'
+import { ByRevision, DNAIdMappings } from '../types'
 import { mapZomeFn } from '../connection'
 import { deleteHandler } from './'
 
@@ -26,26 +26,20 @@ export interface UpdateArgs {
 export type updateHandler = (root: any, args: UpdateArgs) => Promise<ProposalResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const runCreate = mapZomeFn(dnaConfig, conductorUri, 'proposal', 'proposal', 'create_proposal')
-  const runUpdate = mapZomeFn(dnaConfig, conductorUri, 'proposal', 'proposal', 'update_proposal')
-  const runDelete = mapZomeFn(dnaConfig, conductorUri, 'proposal', 'proposal', 'delete_proposal')
+  const runCreate = mapZomeFn<CreateArgs, ProposalResponse>(dnaConfig, conductorUri, 'proposal', 'proposal', 'create_proposal')
+  const runUpdate = mapZomeFn<UpdateArgs, ProposalResponse>(dnaConfig, conductorUri, 'proposal', 'proposal', 'update_proposal')
+  const runDelete = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'proposal', 'proposal', 'delete_proposal')
 
   const createProposal: createHandler = async (root, args) => {
-    const adaptedArguments = {
-      proposal: args.proposal
-    }
-    return runCreate(adaptedArguments)
+    return runCreate(args)
   }
 
   const updateProposal: updateHandler = async (root, args) => {
-    const adaptedArguments = {
-      proposal: args.proposal
-    }
-    return runUpdate(adaptedArguments)
+    return runUpdate(args)
   }
 
   const deleteProposal: deleteHandler = async (root, args) => {
-    return runDelete({ address: args.revisionId })
+    return runDelete(args)
   }
 
   return {

--- a/modules/vf-graphql-holochain/mutations/proposedIntent.ts
+++ b/modules/vf-graphql-holochain/mutations/proposedIntent.ts
@@ -12,7 +12,6 @@ import { deleteHandler } from './'
 import {
   ProposedIntentResponse,
 } from '@valueflows/vf-graphql'
-import { CreateCloneCellRequest } from '@holochain/client'
 
 export interface CreateParams {
   proposedIntent: CreateRequest,

--- a/modules/vf-graphql-holochain/mutations/proposedIntent.ts
+++ b/modules/vf-graphql-holochain/mutations/proposedIntent.ts
@@ -5,7 +5,7 @@
  * @since:   2019-09-12
  */
 
-import { DNAIdMappings } from '../types'
+import { ByRevision, DNAIdMappings, IntentAddress, ProposalAddress } from '../types'
 import { mapZomeFn } from '../connection'
 import { deleteHandler } from './'
 
@@ -13,18 +13,25 @@ import {
   ProposedIntentResponse,
 } from '@valueflows/vf-graphql'
 
+export interface CreateArgs {
+  proposedIntent: {
+    publishedIn: ProposalAddress,
+    publishes: IntentAddress,
+    reciprocal: boolean,
+  },
+}
 export type createHandler = (root: any, args) => Promise<ProposedIntentResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const runCreate = mapZomeFn(dnaConfig, conductorUri, 'proposal', 'proposed_intent', 'create_proposed_intent')
-  const runDelete = mapZomeFn(dnaConfig, conductorUri, 'proposal', 'proposed_intent', 'delete_proposed_intent')
+  const runCreate = mapZomeFn<CreateArgs, ProposedIntentResponse>(dnaConfig, conductorUri, 'proposal', 'proposed_intent', 'create_proposed_intent')
+  const runDelete = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'proposal', 'proposed_intent', 'delete_proposed_intent')
 
   const proposeIntent: createHandler = async (root, args) => {
-    return runCreate({ proposed_intent: args })
+    return runCreate(args)
   }
 
   const deleteProposedIntent: deleteHandler = async (root, args) => {
-    return runDelete({ address: args.revisionId })
+    return runDelete(args)
   }
 
   return {

--- a/modules/vf-graphql-holochain/mutations/proposedIntent.ts
+++ b/modules/vf-graphql-holochain/mutations/proposedIntent.ts
@@ -27,7 +27,7 @@ export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
   const runDelete = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'proposal', 'proposed_intent', 'delete_proposed_intent')
 
   const proposeIntent: createHandler = async (root, args) => {
-    return runCreate(args)
+    return runCreate({ proposedIntent: args })
   }
 
   const deleteProposedIntent: deleteHandler = async (root, args) => {

--- a/modules/vf-graphql-holochain/mutations/proposedIntent.ts
+++ b/modules/vf-graphql-holochain/mutations/proposedIntent.ts
@@ -12,18 +12,20 @@ import { deleteHandler } from './'
 import {
   ProposedIntentResponse,
 } from '@valueflows/vf-graphql'
+import { CreateCloneCellRequest } from '@holochain/client'
 
-export interface CreateArgs {
-  proposedIntent: {
-    publishedIn: ProposalAddress,
-    publishes: IntentAddress,
-    reciprocal: boolean,
-  },
+export interface CreateParams {
+  proposedIntent: CreateRequest,
 }
-export type createHandler = (root: any, args) => Promise<ProposedIntentResponse>
+interface CreateRequest {
+  publishedIn: ProposalAddress,
+  publishes: IntentAddress,
+  reciprocal: boolean,
+}
+export type createHandler = (root: any, args: CreateRequest) => Promise<ProposedIntentResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const runCreate = mapZomeFn<CreateArgs, ProposedIntentResponse>(dnaConfig, conductorUri, 'proposal', 'proposed_intent', 'create_proposed_intent')
+  const runCreate = mapZomeFn<CreateParams, ProposedIntentResponse>(dnaConfig, conductorUri, 'proposal', 'proposed_intent', 'create_proposed_intent')
   const runDelete = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'proposal', 'proposed_intent', 'delete_proposed_intent')
 
   const proposeIntent: createHandler = async (root, args) => {

--- a/modules/vf-graphql-holochain/mutations/proposedTo.ts
+++ b/modules/vf-graphql-holochain/mutations/proposedTo.ts
@@ -13,16 +13,17 @@ import {
   ProposedToResponse,
 } from '@valueflows/vf-graphql'
 
-export interface CreateArgs {
-  proposedTo: {
+export interface CreateParams {
+  proposedTo: CreateRequest,
+}
+interface CreateRequest {
     proposed: ProposalAddress,
     proposedTo: AgentAddress,
-  },
 }
-export type createHandler = (root: any, args) => Promise<ProposedToResponse>
+export type createHandler = (root: any, args: CreateRequest) => Promise<ProposedToResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const runCreate = mapZomeFn<CreateArgs, ProposedToResponse>(dnaConfig, conductorUri, 'proposal', 'proposed_to', 'create_proposed_to')
+  const runCreate = mapZomeFn<CreateParams, ProposedToResponse>(dnaConfig, conductorUri, 'proposal', 'proposed_to', 'create_proposed_to')
   const runDelete = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'proposal', 'proposed_to', 'delete_proposed_to')
 
   const proposeTo: createHandler = async (root, args) => {

--- a/modules/vf-graphql-holochain/mutations/proposedTo.ts
+++ b/modules/vf-graphql-holochain/mutations/proposedTo.ts
@@ -5,7 +5,7 @@
  * @since:   2019-09-12
  */
 
-import { DNAIdMappings } from '../types'
+import { AgentAddress, ByRevision, DNAIdMappings, ProposalAddress } from '../types'
 import { mapZomeFn } from '../connection'
 import { deleteHandler } from './'
 
@@ -13,18 +13,25 @@ import {
   ProposedToResponse,
 } from '@valueflows/vf-graphql'
 
+export interface CreateArgs {
+  proposedTo: {
+    proposed: AgentAddress,
+    publishes: ProposalAddress,
+    reciprocal: boolean,
+  },
+}
 export type createHandler = (root: any, args) => Promise<ProposedToResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const runCreate = mapZomeFn(dnaConfig, conductorUri, 'proposal', 'proposed_to', 'create_proposed_to')
-  const runDelete = mapZomeFn(dnaConfig, conductorUri, 'proposal', 'proposed_to', 'delete_proposed_to')
+  const runCreate = mapZomeFn<CreateArgs, ProposedToResponse>(dnaConfig, conductorUri, 'proposal', 'proposed_to', 'create_proposed_to')
+  const runDelete = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'proposal', 'proposed_to', 'delete_proposed_to')
 
   const proposeTo: createHandler = async (root, args) => {
-    return runCreate({ proposed_to: args })
+    return runCreate(args)
   }
 
   const deleteProposedTo: deleteHandler = async (root, args) => {
-    return runDelete({ address: args.revisionId })
+    return runDelete(args)
   }
 
   return {

--- a/modules/vf-graphql-holochain/mutations/proposedTo.ts
+++ b/modules/vf-graphql-holochain/mutations/proposedTo.ts
@@ -15,9 +15,8 @@ import {
 
 export interface CreateArgs {
   proposedTo: {
-    proposed: AgentAddress,
-    publishes: ProposalAddress,
-    reciprocal: boolean,
+    proposed: ProposalAddress,
+    proposedTo: AgentAddress,
   },
 }
 export type createHandler = (root: any, args) => Promise<ProposedToResponse>
@@ -27,7 +26,7 @@ export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
   const runDelete = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'proposal', 'proposed_to', 'delete_proposed_to')
 
   const proposeTo: createHandler = async (root, args) => {
-    return runCreate(args)
+    return runCreate({ proposedTo: args })
   }
 
   const deleteProposedTo: deleteHandler = async (root, args) => {

--- a/modules/vf-graphql-holochain/mutations/resourceSpecification.ts
+++ b/modules/vf-graphql-holochain/mutations/resourceSpecification.ts
@@ -5,7 +5,7 @@
  * @since:   2019-09-12
  */
 
-import { DNAIdMappings } from '../types'
+import { ByRevision, DNAIdMappings } from '../types'
 import { mapZomeFn } from '../connection'
 import { deleteHandler } from './'
 
@@ -26,24 +26,20 @@ export interface UpdateArgs {
 export type updateHandler = (root: any, args: UpdateArgs) => Promise<ResourceSpecificationResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const runCreate = mapZomeFn(dnaConfig, conductorUri, 'specification', 'resource_specification', 'create_resource_specification')
-  const runUpdate = mapZomeFn(dnaConfig, conductorUri, 'specification', 'resource_specification', 'update_resource_specification')
-  const runDelete = mapZomeFn(dnaConfig, conductorUri, 'specification', 'resource_specification', 'delete_resource_specification')
+  const runCreate = mapZomeFn<CreateArgs, ResourceSpecificationResponse>(dnaConfig, conductorUri, 'specification', 'resource_specification', 'create_resource_specification')
+  const runUpdate = mapZomeFn<UpdateArgs, ResourceSpecificationResponse>(dnaConfig, conductorUri, 'specification', 'resource_specification', 'update_resource_specification')
+  const runDelete = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'specification', 'resource_specification', 'delete_resource_specification')
 
   const createResourceSpecification: createHandler = async (root, args) => {
-    return runCreate({
-      resource_specification: args.resourceSpecification
-    })
+    return runCreate(args)
   }
 
   const updateResourceSpecification: updateHandler = async (root, args) => {
-    return runUpdate({
-      resource_specification: args.resourceSpecification
-    })
+    return runUpdate(args)
   }
 
   const deleteResourceSpecification: deleteHandler = async (root, args) => {
-    return runDelete({ address: args.revisionId })
+    return runDelete(args)
   }
 
   return {

--- a/modules/vf-graphql-holochain/mutations/satisfaction.ts
+++ b/modules/vf-graphql-holochain/mutations/satisfaction.ts
@@ -5,7 +5,7 @@
  * @since:   2019-08-31
  */
 
-import { DNAIdMappings } from '../types'
+import { ByRevision, DNAIdMappings } from '../types'
 import { mapZomeFn } from '../connection'
 import { deleteHandler } from './'
 
@@ -26,9 +26,9 @@ export interface UpdateArgs {
 export type updateHandler = (root: any, args: UpdateArgs) => Promise<SatisfactionResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const runCreate = mapZomeFn(dnaConfig, conductorUri, 'planning', 'satisfaction', 'create_satisfaction')
-  const runUpdate = mapZomeFn(dnaConfig, conductorUri, 'planning', 'satisfaction', 'update_satisfaction')
-  const runDelete = mapZomeFn(dnaConfig, conductorUri, 'planning', 'satisfaction', 'delete_satisfaction')
+  const runCreate = mapZomeFn<CreateArgs, SatisfactionResponse>(dnaConfig, conductorUri, 'planning', 'satisfaction', 'create_satisfaction')
+  const runUpdate = mapZomeFn<UpdateArgs, SatisfactionResponse>(dnaConfig, conductorUri, 'planning', 'satisfaction', 'update_satisfaction')
+  const runDelete = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'planning', 'satisfaction', 'delete_satisfaction')
 
   const createSatisfaction: createHandler = async (root, args) => {
     return runCreate(args)
@@ -39,7 +39,7 @@ export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
   }
 
   const deleteSatisfaction: deleteHandler = async (root, args) => {
-    return runDelete({ address: args.revisionId })
+    return runDelete(args)
   }
 
   return {

--- a/modules/vf-graphql-holochain/mutations/unit.ts
+++ b/modules/vf-graphql-holochain/mutations/unit.ts
@@ -5,7 +5,7 @@
  * @since:   2019-09-12
  */
 
-import { DNAIdMappings } from '../types'
+import { ByRevision, DNAIdMappings } from '../types'
 import { mapZomeFn } from '../connection'
 import { deleteHandler } from './'
 
@@ -26,9 +26,9 @@ export interface UpdateArgs {
 export type updateHandler = (root: any, args: UpdateArgs) => Promise<UnitResponse>
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const runCreate = mapZomeFn(dnaConfig, conductorUri, 'specification', 'unit', 'create_unit')
-  const runUpdate = mapZomeFn(dnaConfig, conductorUri, 'specification', 'unit', 'update_unit')
-  const runDelete = mapZomeFn(dnaConfig, conductorUri, 'specification', 'unit', 'delete_unit')
+  const runCreate = mapZomeFn<CreateArgs, UnitResponse>(dnaConfig, conductorUri, 'specification', 'unit', 'create_unit')
+  const runUpdate = mapZomeFn<UpdateArgs, UnitResponse>(dnaConfig, conductorUri, 'specification', 'unit', 'update_unit')
+  const runDelete = mapZomeFn<ByRevision, boolean>(dnaConfig, conductorUri, 'specification', 'unit', 'delete_unit')
 
   const createUnit: createHandler = async (root, args) => {
     return runCreate(args)
@@ -39,7 +39,7 @@ export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
   }
 
   const deleteUnit: deleteHandler = async (root, args) => {
-    return runDelete({ address: args.revisionId })
+    return runDelete(args)
   }
 
   return {

--- a/modules/vf-graphql-holochain/queries/action.ts
+++ b/modules/vf-graphql-holochain/queries/action.ts
@@ -14,15 +14,15 @@ import {
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
   const read = mapZomeFn<ReadParams, Action>(dnaConfig, conductorUri, 'specification', 'action', 'get_action')
-  // const readAll = mapZomeFn<null, Action[]>(dnaConfig, conductorUri, 'specification', 'action', 'get_all_actions')
+  const readAll = mapZomeFn<null, Action[]>(dnaConfig, conductorUri, 'specification', 'action', 'get_all_actions')
 
   return {
     action: async (root, args): Promise<Action> => {
       return read(args)
     },
 
-    // actions: async (root, args): Promise<Action[]> => {
-    //   return readAll(null)
-    // },
+    actions: async (root, args): Promise<Action[]> => {
+      return readAll(null)
+    },
   }
 }

--- a/modules/vf-graphql-holochain/queries/action.ts
+++ b/modules/vf-graphql-holochain/queries/action.ts
@@ -5,7 +5,7 @@
  * @since:   2019-12-23
  */
 
-import { DNAIdMappings } from '../types'
+import { DNAIdMappings, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
@@ -13,16 +13,16 @@ import {
 } from '@valueflows/vf-graphql'
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const read = mapZomeFn(dnaConfig, conductorUri, 'specification', 'action', 'get_action')
-  const readAll = mapZomeFn(dnaConfig, conductorUri, 'specification', 'action', 'get_all_actions')
+  const read = mapZomeFn<ReadParams, Action>(dnaConfig, conductorUri, 'specification', 'action', 'get_action')
+  // const readAll = mapZomeFn<null, Action[]>(dnaConfig, conductorUri, 'specification', 'action', 'get_all_actions')
 
   return {
     action: async (root, args): Promise<Action> => {
       return read(args)
     },
 
-    actions: async (root, args): Promise<Action> => {
-      return readAll(null)
-    },
+    // actions: async (root, args): Promise<Action[]> => {
+    //   return readAll(null)
+    // },
   }
 }

--- a/modules/vf-graphql-holochain/queries/agent.ts
+++ b/modules/vf-graphql-holochain/queries/agent.ts
@@ -37,7 +37,13 @@ export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
       // :TODO: wire to Personas hApp
       return {
         id: `${agentPubKey}:${mappedDNA}`,
+        revisionId: '',
         name: `Agent ${agentPubKey.substr(2, 4)}`,
+        meta: {
+          retrievedRevision: {
+            id: '',
+          }
+        }
       }
     }),
 
@@ -46,9 +52,15 @@ export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
     agents: async (root, args): Promise<Agent[]> => {
       return (await readAllAgents(null)).map(agentAddress => ({
         // :TODO: wire to Personas hApp
-        id: agentAddress,
-        name: `Agent ${agentAddress.substr(2, 4)}`,
+        id: `${serializeHash(agentAddress)}:${mappedDNA}`,
+        revisionId: '',
+        name: `Agent ${serializeHash(agentAddress).substr(2, 4)}`,
         __typename: 'Person',  // :SHONK:
+        meta: {
+          retrievedRevision: {
+            id: ''
+          }
+        }
       }))
     },
 
@@ -61,7 +73,13 @@ export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
       }
       return {
         id,
+        revisionId: '',
         name: `Agent ${id.substr(2, 4)}`,
+        meta: {
+          retrievedRevision: {
+            id: '',
+          }
+        }
       }
     }),
   }

--- a/modules/vf-graphql-holochain/queries/agent.ts
+++ b/modules/vf-graphql-holochain/queries/agent.ts
@@ -13,13 +13,19 @@ import { mapZomeFn, serializeHash, deserializeHash } from '../connection'
 import {
   Agent
 } from '@valueflows/vf-graphql'
+import { AgentPubKey } from '@holochain/client'
+
+export interface RegistrationQueryParams {
+  pubKey: AgentPubKey,
+}
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const readMyAgent = mapZomeFn(dnaConfig, conductorUri, 'agent', 'agent_registration', 'get_my_agent_pubkey')
-  const readAllAgents = mapZomeFn(dnaConfig, conductorUri, 'agent', 'agent_registration', 'get_registered')
+
+  const readMyAgent = mapZomeFn<null, AgentPubKey>(dnaConfig, conductorUri, 'agent', 'agent_registration', 'get_my_agent_pubkey')
+  const readAllAgents = mapZomeFn<null, AgentPubKey[]>(dnaConfig, conductorUri, 'agent', 'agent_registration', 'get_registered')
   // special 'true' at the end is for skipEncodeDecode, because of the way this zome handles serialization and inputs
   // which is different from others
-  const agentExists = mapZomeFn(dnaConfig, conductorUri, 'agent', 'agent_registration', 'is_registered', true)
+  const agentExists = mapZomeFn<RegistrationQueryParams, boolean>(dnaConfig, conductorUri, 'agent', 'agent_registration', 'is_registered', true)
 
   // read mapped DNA hash in order to construct VF-native IDs from DNA-local HC IDs
   const mappedDNA = dnaConfig['agent'] ? serializeHash(dnaConfig['agent'][0]) : null

--- a/modules/vf-graphql-holochain/queries/agreement.ts
+++ b/modules/vf-graphql-holochain/queries/agreement.ts
@@ -17,7 +17,7 @@ export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
 
   return {
     agreement: async (root, args): Promise<Agreement> => {
-      return (await readRecord(args)).agreement
+      return (await readRecord({ address: args.id })).agreement
     },
   }
 }

--- a/modules/vf-graphql-holochain/queries/agreement.ts
+++ b/modules/vf-graphql-holochain/queries/agreement.ts
@@ -16,7 +16,6 @@ export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
   const readRecord = mapZomeFn<ReadParams, AgreementResponse>(dnaConfig, conductorUri, 'agreement', 'agreement', 'get_agreement')
 
   return {
-    // why does agreement query not return AgreementResponse like other queries?
     agreement: async (root, args): Promise<Agreement> => {
       return (await readRecord(args)).agreement
     },

--- a/modules/vf-graphql-holochain/queries/agreement.ts
+++ b/modules/vf-graphql-holochain/queries/agreement.ts
@@ -5,19 +5,20 @@
  * @since:   2020-06-16
  */
 
-import { DNAIdMappings } from '../types'
+import { DNAIdMappings, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
-  Agreement,
+  Agreement, AgreementResponse,
 } from '@valueflows/vf-graphql'
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const readRecord = mapZomeFn(dnaConfig, conductorUri, 'agreement', 'agreement', 'get_agreement')
+  const readRecord = mapZomeFn<ReadParams, AgreementResponse>(dnaConfig, conductorUri, 'agreement', 'agreement', 'get_agreement')
 
   return {
-    agreement: async (root, { id }): Promise<Agreement> => {
-      return (await readRecord({ address: id })).agreement
+    // why does agreement query not return AgreementResponse like other queries?
+    agreement: async (root, args): Promise<Agreement> => {
+      return (await readRecord(args)).agreement
     },
   }
 }

--- a/modules/vf-graphql-holochain/queries/commitment.ts
+++ b/modules/vf-graphql-holochain/queries/commitment.ts
@@ -5,15 +5,15 @@
  * @since:   2019-08-28
  */
 
-import { DNAIdMappings, injectTypename } from '../types'
+import { DNAIdMappings, injectTypename, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
-  Commitment,
+  Commitment, CommitmentResponse,
 } from '@valueflows/vf-graphql'
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const readOne = mapZomeFn(dnaConfig, conductorUri, 'planning', 'commitment', 'get_commitment')
+  const readOne = mapZomeFn<ReadParams, CommitmentResponse>(dnaConfig, conductorUri, 'planning', 'commitment', 'get_commitment')
 
   return {
     commitment: injectTypename('Commitment', async (root, args): Promise<Commitment> => {

--- a/modules/vf-graphql-holochain/queries/economicEvent.ts
+++ b/modules/vf-graphql-holochain/queries/economicEvent.ts
@@ -5,17 +5,18 @@
  * @since:   2019-05-27
  */
 
-import { DNAIdMappings, injectTypename } from '../types'
+import { DNAIdMappings, injectTypename, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
   EconomicEvent,
   EconomicEventConnection,
+  EconomicEventResponse,
 } from '@valueflows/vf-graphql'
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const readOne = mapZomeFn(dnaConfig, conductorUri, 'observation', 'economic_event', 'get_economic_event')
-  const readAll = mapZomeFn(dnaConfig, conductorUri, 'observation', 'economic_event', 'get_all_economic_events')
+  const readOne = mapZomeFn<ReadParams, EconomicEventResponse>(dnaConfig, conductorUri, 'observation', 'economic_event', 'get_economic_event')
+  const readAll = mapZomeFn<null, EconomicEventConnection>(dnaConfig, conductorUri, 'observation', 'economic_event', 'get_all_economic_events')
 
   return {
     economicEvent: injectTypename('EconomicEvent', async (root, args): Promise<EconomicEvent> => {

--- a/modules/vf-graphql-holochain/queries/economicResource.ts
+++ b/modules/vf-graphql-holochain/queries/economicResource.ts
@@ -5,17 +5,18 @@
  * @since:   2019-10-31
  */
 
-import { DNAIdMappings } from '../types'
+import { DNAIdMappings, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
   EconomicResource,
   EconomicResourceConnection,
+  EconomicResourceResponse,
 } from '@valueflows/vf-graphql'
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const readOne = mapZomeFn(dnaConfig, conductorUri, 'observation', 'economic_resource', 'get_economic_resource')
-  const readAll = mapZomeFn(dnaConfig, conductorUri, 'observation', 'economic_resource', 'get_all_economic_resources')
+  const readOne = mapZomeFn<ReadParams, EconomicResourceResponse>(dnaConfig, conductorUri, 'observation', 'economic_resource', 'get_economic_resource')
+  const readAll = mapZomeFn<null, EconomicResourceConnection>(dnaConfig, conductorUri, 'observation', 'economic_resource', 'get_all_economic_resources')
 
   return {
     economicResource: async (root, args): Promise<EconomicResource> => {

--- a/modules/vf-graphql-holochain/queries/fulfillment.ts
+++ b/modules/vf-graphql-holochain/queries/fulfillment.ts
@@ -5,7 +5,7 @@
  * @since:   2019-08-28
  */
 
-import { DNAIdMappings } from '../types'
+import { DNAIdMappings, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {

--- a/modules/vf-graphql-holochain/queries/fulfillment.ts
+++ b/modules/vf-graphql-holochain/queries/fulfillment.ts
@@ -9,11 +9,11 @@ import { DNAIdMappings } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
-  Fulfillment,
+  Fulfillment, FulfillmentResponse,
 } from '@valueflows/vf-graphql'
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const readOne = mapZomeFn(dnaConfig, conductorUri, 'planning', 'fulfillment', 'get_fulfillment')
+  const readOne = mapZomeFn<ReadParams, FulfillmentResponse>(dnaConfig, conductorUri, 'planning', 'fulfillment', 'get_fulfillment')
 
   return {
     fulfillment: async (root, args): Promise<Fulfillment> => {

--- a/modules/vf-graphql-holochain/queries/intent.ts
+++ b/modules/vf-graphql-holochain/queries/intent.ts
@@ -18,7 +18,7 @@ export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
 
   return {
     intent: async (root, args): Promise<Intent> => {
-      return (await (await readRecord)(args)).intent
+      return (await readRecord({ address: args.id })).intent
     },
   }
 }

--- a/modules/vf-graphql-holochain/queries/intent.ts
+++ b/modules/vf-graphql-holochain/queries/intent.ts
@@ -5,20 +5,20 @@
  * @since:   2019-08-31
  */
 
-import { DNAIdMappings } from '../types'
+import { DNAIdMappings, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
-  Intent,
+  Intent, IntentResponse,
 } from '@valueflows/vf-graphql'
 
 // :TODO: how to inject DNA identifier?
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const readRecord = mapZomeFn(dnaConfig, conductorUri, 'planning', 'intent', 'get_intent')
+  const readRecord = mapZomeFn<ReadParams, IntentResponse>(dnaConfig, conductorUri, 'planning', 'intent', 'get_intent')
 
   return {
     intent: async (root, args): Promise<Intent> => {
-      return (await (await readRecord)({ address: args.id })).intent
+      return (await (await readRecord)(args)).intent
     },
   }
 }

--- a/modules/vf-graphql-holochain/queries/plan.ts
+++ b/modules/vf-graphql-holochain/queries/plan.ts
@@ -5,26 +5,27 @@
  * @since:   2019-05-27
  */
 
-import { DNAIdMappings, injectTypename } from '../types'
+import { DNAIdMappings, injectTypename, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
     Plan,
     PlanConnection,
+    PlanResponse,
 } from '@valueflows/vf-graphql'
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const readOne = mapZomeFn(dnaConfig, conductorUri, 'plan', 'plan', 'get_plan')
-  const readAll = mapZomeFn(dnaConfig, conductorUri, 'plan', 'plan_index', 'read_all_plans')
+  const readOne = mapZomeFn<ReadParams, PlanResponse>(dnaConfig, conductorUri, 'plan', 'plan', 'get_plan')
+  // const readAll = mapZomeFn(dnaConfig, conductorUri, 'plan', 'plan_index', 'get_all_plans')
 
   return {
     plan: injectTypename('Plan', async (root, args): Promise<Plan> => {
       return (await readOne({ address: args.id })).plan
     }),
 
-    plans: async (root, args): Promise<PlanConnection> => {
-      return await readAll(null)
-    },
+    // plans: async (root, args): Promise<PlanConnection> => {
+    //   return await readAll(null)
+    // },
   }
 }
 

--- a/modules/vf-graphql-holochain/queries/process.ts
+++ b/modules/vf-graphql-holochain/queries/process.ts
@@ -5,15 +5,15 @@
  * @since:   2019-09-12
  */
 
-import { DNAIdMappings } from '../types'
+import { DNAIdMappings, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
-  Process,
+  Process, ProcessResponse,
 } from '@valueflows/vf-graphql'
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const readOne = mapZomeFn(dnaConfig, conductorUri, 'observation', 'process', 'get_process')
+  const readOne = mapZomeFn<ReadParams, ProcessResponse>(dnaConfig, conductorUri, 'observation', 'process', 'get_process')
 
   return {
     process: async (root, args): Promise<Process> => {

--- a/modules/vf-graphql-holochain/queries/processSpecification.ts
+++ b/modules/vf-graphql-holochain/queries/processSpecification.ts
@@ -5,15 +5,15 @@
  * @since:   2019-09-12
  */
 
-import { DNAIdMappings } from '../types'
+import { DNAIdMappings, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
-  ProcessSpecification,
+  ProcessSpecification, ProcessSpecificationResponse,
 } from '@valueflows/vf-graphql'
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const readOne = mapZomeFn(dnaConfig, conductorUri, 'specification', 'process_specification', 'get_process_specification')
+  const readOne = mapZomeFn<ReadParams, ProcessSpecificationResponse>(dnaConfig, conductorUri, 'specification', 'process_specification', 'get_process_specification')
 
   return {
     processSpecification: async (root, args): Promise<ProcessSpecification> => {

--- a/modules/vf-graphql-holochain/queries/proposal.ts
+++ b/modules/vf-graphql-holochain/queries/proposal.ts
@@ -5,17 +5,18 @@
  * @since:   2019-09-12
  */
 
-import { DNAIdMappings } from '../types'
+import { DNAIdMappings, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
   Proposal,
   ProposedTo,
   ProposedIntent,
+  ProposalResponse,
 } from '@valueflows/vf-graphql'
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const readOne = mapZomeFn(dnaConfig, conductorUri, 'proposal', 'proposal', 'get_proposal')
+  const readOne = mapZomeFn<ReadParams, ProposalResponse>(dnaConfig, conductorUri, 'proposal', 'proposal', 'get_proposal')
 
   return {
     proposal: async (root, args): Promise<Proposal> => {

--- a/modules/vf-graphql-holochain/queries/resourceSpecification.ts
+++ b/modules/vf-graphql-holochain/queries/resourceSpecification.ts
@@ -5,15 +5,15 @@
  * @since:   2019-09-12
  */
 
-import { DNAIdMappings } from '../types'
+import { DNAIdMappings, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
-  ResourceSpecification,
+  ResourceSpecification, ResourceSpecificationResponse,
 } from '@valueflows/vf-graphql'
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const readOne = mapZomeFn(dnaConfig, conductorUri, 'specification', 'resource_specification', 'get_resource_specification')
+  const readOne = mapZomeFn<ReadParams, ResourceSpecificationResponse>(dnaConfig, conductorUri, 'specification', 'resource_specification', 'get_resource_specification')
 
   return {
     resourceSpecification: async (root, args): Promise<ResourceSpecification> => {

--- a/modules/vf-graphql-holochain/queries/satisfaction.ts
+++ b/modules/vf-graphql-holochain/queries/satisfaction.ts
@@ -5,15 +5,15 @@
  * @since:   2019-08-31
  */
 
-import { DNAIdMappings } from '../types'
+import { DNAIdMappings, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
-  Satisfaction,
+  Satisfaction, SatisfactionResponse,
 } from '@valueflows/vf-graphql'
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const readOne = mapZomeFn(dnaConfig, conductorUri, 'planning', 'satisfaction', 'get_satisfaction')
+  const readOne = mapZomeFn<ReadParams, SatisfactionResponse>(dnaConfig, conductorUri, 'planning', 'satisfaction', 'get_satisfaction')
 
   return {
     satisfaction: async (root, args): Promise<Satisfaction> => {

--- a/modules/vf-graphql-holochain/queries/unit.ts
+++ b/modules/vf-graphql-holochain/queries/unit.ts
@@ -5,15 +5,15 @@
  * @since:   2019-09-12
  */
 
-import { DNAIdMappings } from '../types'
+import { DNAIdMappings, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
-  Unit,
+  Unit, UnitResponse,
 } from '@valueflows/vf-graphql'
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const readOne = mapZomeFn(dnaConfig, conductorUri, 'specification', 'unit', 'get_unit')
+  const readOne = mapZomeFn<ReadParams, UnitResponse>(dnaConfig, conductorUri, 'specification', 'unit', 'get_unit')
 
   return {
     unit: async (root, args): Promise<Unit> => {

--- a/modules/vf-graphql-holochain/resolvers/agreement.ts
+++ b/modules/vf-graphql-holochain/resolvers/agreement.ts
@@ -6,38 +6,35 @@
  */
 
 import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule } from '../types'
-import { mapZomeFn } from '../connection'
+import { extractEdges, mapZomeFn } from '../connection'
 
 import {
   Agreement,
   Commitment,
+  CommitmentConnection,
   EconomicEvent,
+  EconomicEventConnection,
 } from '@valueflows/vf-graphql'
+import { CommitmentSearchInput, EconomicEventSearchInput } from './zomeSearchInputTypes'
 
 export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DNAIdMappings, conductorUri: string) => {
   const hasObservation = -1 !== enabledVFModules.indexOf(VfModule.Observation)
   const hasPlanning = -1 !== enabledVFModules.indexOf(VfModule.Planning)
 
-  const queryCommitments = mapZomeFn(dnaConfig, conductorUri, 'planning', 'commitment_index', 'query_commitments')
-  const queryEvents = mapZomeFn(dnaConfig, conductorUri, 'observation', 'economic_event_index', 'query_economic_events')
+  const queryCommitments = mapZomeFn<CommitmentSearchInput,CommitmentConnection>(dnaConfig, conductorUri, 'planning', 'commitment_index', 'query_commitments')
+  const queryEvents = mapZomeFn<EconomicEventSearchInput, EconomicEventConnection>(dnaConfig, conductorUri, 'observation', 'economic_event_index', 'query_economic_events')
 
   return Object.assign(
     (hasPlanning ? {
       commitments: async (record: Agreement): Promise<Commitment[]> => {
         const commitments = await queryCommitments({ params: { clauseOf: record.id } })
-        if (!commitments.edges || !commitments.edges.length) {
-          return []
-        }
-        return commitments.edges.map(({ node }) => node)
+        return extractEdges(commitments)
       },
     } : {}),
     (hasObservation ? {
       economicEvents: async (record: Agreement): Promise<EconomicEvent[]> => {
         const economicEvents = await queryEvents({ params: { realizationOf: record.id } })
-        if (!economicEvents.edges || !economicEvents.edges.length) {
-          return []
-        }
-        return economicEvents.edges.map(({ node }) => node)
+        return extractEdges(economicEvents)
       },
     } : {}),
   )

--- a/modules/vf-graphql-holochain/resolvers/commitment.ts
+++ b/modules/vf-graphql-holochain/resolvers/commitment.ts
@@ -5,7 +5,7 @@
  * @since:   2019-08-28
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ReadParams, ById } from '../types'
 import { extractEdges, mapZomeFn } from '../connection'
 
 import {
@@ -18,11 +18,16 @@ import {
   Action,
   Agreement,
   Plan,
+  FulfillmentConnection,
+  ProcessConnection,
+  SatisfactionConnection,
+  ResourceSpecificationResponse,
 } from '@valueflows/vf-graphql'
 
 import agentQueries from '../queries/agent'
 import agreementQueries from '../queries/agreement'
 import planQueries from '../queries/plan'
+import { FulfillmentSearchInput, ProcessSearchInput, SatisfactionSearchInput } from './zomeSearchInputTypes'
 
 export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DNAIdMappings, conductorUri: string) => {
   const hasAgent = -1 !== enabledVFModules.indexOf(VfModule.Agent)
@@ -31,11 +36,11 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
   const hasAgreement = -1 !== enabledVFModules.indexOf(VfModule.Agreement)
   const hasPlan = -1 !== enabledVFModules.indexOf(VfModule.Plan)
 
-  const readFulfillments = mapZomeFn(dnaConfig, conductorUri, 'planning', 'fulfillment_index', 'query_fulfillments')
-  const readSatisfactions = mapZomeFn(dnaConfig, conductorUri, 'planning', 'satisfaction_index', 'query_satisfactions')
-  const readProcesses = mapZomeFn(dnaConfig, conductorUri, 'observation', 'process_index', 'query_processes')
-  const readResourceSpecification = mapZomeFn(dnaConfig, conductorUri, 'specification', 'resource_specification', 'get_resource_specification')
-  const readAction = mapZomeFn(dnaConfig, conductorUri, 'specification', 'action', 'get_action')
+  const readFulfillments = mapZomeFn<FulfillmentSearchInput, FulfillmentConnection>(dnaConfig, conductorUri, 'planning', 'fulfillment_index', 'query_fulfillments')
+  const readSatisfactions = mapZomeFn<SatisfactionSearchInput, SatisfactionConnection>(dnaConfig, conductorUri, 'planning', 'satisfaction_index', 'query_satisfactions')
+  const readProcesses = mapZomeFn<ProcessSearchInput, ProcessConnection>(dnaConfig, conductorUri, 'observation', 'process_index', 'query_processes')
+  const readResourceSpecification = mapZomeFn<ReadParams, ResourceSpecificationResponse>(dnaConfig, conductorUri, 'specification', 'resource_specification', 'get_resource_specification')
+  const readAction = mapZomeFn<ById, Action>(dnaConfig, conductorUri, 'specification', 'action', 'get_action')
   const readPlan = planQueries(dnaConfig, conductorUri)['plan']
   const readAgent = agentQueries(dnaConfig, conductorUri)['agent']
   const readAgreement = agreementQueries(dnaConfig, conductorUri)['agreement']

--- a/modules/vf-graphql-holochain/resolvers/commitment.ts
+++ b/modules/vf-graphql-holochain/resolvers/commitment.ts
@@ -5,7 +5,7 @@
  * @since:   2019-08-28
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ReadParams, ById } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ReadParams, ById, ResourceSpecificationAddress, AddressableIdentifier } from '../types'
 import { extractEdges, mapZomeFn } from '../connection'
 
 import {
@@ -78,11 +78,11 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
       },
     } : {}),
     (hasKnowledge ? {
-      resourceConformsTo: async (record: Commitment): Promise<ResourceSpecification> => {
+      resourceConformsTo: async (record: { resourceConformsTo: ResourceSpecificationAddress }): Promise<ResourceSpecification> => {
         return (await readResourceSpecification({ address: record.resourceConformsTo })).resourceSpecification
       },
 
-      action: async (record: Commitment): Promise<Action> => {
+      action: async (record: { action: AddressableIdentifier }): Promise<Action> => {
         return (await readAction({ id: record.action }))
       },
     } : {}),

--- a/modules/vf-graphql-holochain/resolvers/commitment.ts
+++ b/modules/vf-graphql-holochain/resolvers/commitment.ts
@@ -67,14 +67,14 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
       },
     } : {}),
     (hasObservation ? {
-      inputOf: async (record: Commitment): Promise<Process[]> => {
+      inputOf: async (record: Commitment): Promise<Process> => {
         const results = await readProcesses({ params: { committedInputs: record.id } })
-        return results.edges.pop()['node']
+        return results.edges.pop()!['node']
       },
 
-      outputOf: async (record: Commitment): Promise<Process[]> => {
+      outputOf: async (record: Commitment): Promise<Process> => {
         const results = await readProcesses({ params: { committedOutputs: record.id } })
-        return results.edges.pop()['node']
+        return results.edges.pop()!['node']
       },
     } : {}),
     (hasKnowledge ? {

--- a/modules/vf-graphql-holochain/resolvers/economicEvent.ts
+++ b/modules/vf-graphql-holochain/resolvers/economicEvent.ts
@@ -5,7 +5,7 @@
  * @since:   2019-08-27
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ById, ReadParams } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ById, ReadParams, ResourceSpecificationAddress, AddressableIdentifier } from '../types'
 import { extractEdges, mapZomeFn } from '../connection'
 
 import {
@@ -82,12 +82,12 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
       },
     } : {}),
     (hasKnowledge ? {
-      resourceConformsTo: async (record: EconomicEvent): Promise<ResourceSpecification> => {
+      resourceConformsTo: async (record: { resourceConformsTo: ResourceSpecificationAddress }): Promise<ResourceSpecification> => {
         // record isn't quite an `EconomicEvent` since it stores ids for linked types, not the type itself, right?
         return (await readResourceSpecification({ address: record.resourceConformsTo })).resourceSpecification
       },
 
-      action: async (record: EconomicEvent): Promise<Action> => {
+      action: async (record: { action: AddressableIdentifier }): Promise<Action> => {
         return (await readAction({ id: record.action }))
       },
     } : {}),

--- a/modules/vf-graphql-holochain/resolvers/economicEvent.ts
+++ b/modules/vf-graphql-holochain/resolvers/economicEvent.ts
@@ -48,13 +48,12 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
     {
       inputOf: async (record: EconomicEvent): Promise<Process> => {
         const results = await readProcesses({ params: { inputs: record.id } })
-        return results.edges.pop()['node']
-        // Originally this returned Process[], but it should just return Process, same as `outputOf` below
+        return results.edges.pop()!['node']
       },
 
       outputOf: async (record: EconomicEvent): Promise<Process> => {
         const results = await readProcesses({ params: { outputs: record.id } })
-        return results.edges.pop()['node']
+        return results.edges.pop()!['node']
       },
 
       resourceInventoriedAs: async (record: EconomicEvent): Promise<EconomicResource | null> => {

--- a/modules/vf-graphql-holochain/resolvers/economicResource.ts
+++ b/modules/vf-graphql-holochain/resolvers/economicResource.ts
@@ -5,7 +5,7 @@
  * @since:   2019-10-31
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ById, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
@@ -15,17 +15,22 @@ import {
   ProcessSpecification,
   Action,
   Maybe,
+  EconomicResourceConnection,
+  UnitResponse,
+  ProcessSpecificationResponse,
+  ResourceSpecificationResponse,
 } from '@valueflows/vf-graphql'
+import { EconomicResourceSearchInput } from './zomeSearchInputTypes'
 
 export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DNAIdMappings, conductorUri: string) => {
   const hasMeasurement = -1 !== enabledVFModules.indexOf(VfModule.Measurement)
   const hasKnowledge = -1 !== enabledVFModules.indexOf(VfModule.Knowledge)
 
-  const readResources = mapZomeFn(dnaConfig, conductorUri, 'observation', 'economic_resource_index', 'query_economic_resources')
-  const readUnit = mapZomeFn(dnaConfig, conductorUri, 'specification', 'unit', 'get_unit')
-  const readProcessSpecification = mapZomeFn(dnaConfig, conductorUri, 'specification', 'process_specification', 'get_process_specification')
-  const readAction = mapZomeFn(dnaConfig, conductorUri, 'specification', 'action', 'get_action')
-  const readResourceSpecification = mapZomeFn(dnaConfig, conductorUri, 'specification', 'resource_specification', 'get_resource_specification')
+  const readResources = mapZomeFn<EconomicResourceSearchInput, EconomicResourceConnection>(dnaConfig, conductorUri, 'observation', 'economic_resource_index', 'query_economic_resources')
+  const readUnit = mapZomeFn<ById, UnitResponse>(dnaConfig, conductorUri, 'specification', 'unit', 'get_unit')
+  const readProcessSpecification = mapZomeFn<ReadParams, ProcessSpecificationResponse>(dnaConfig, conductorUri, 'specification', 'process_specification', 'get_process_specification')
+  const readAction = mapZomeFn<ById, Action>(dnaConfig, conductorUri, 'specification', 'action', 'get_action')
+  const readResourceSpecification = mapZomeFn<ReadParams, ResourceSpecificationResponse>(dnaConfig, conductorUri, 'specification', 'resource_specification', 'get_resource_specification')
 
   return Object.assign(
     {

--- a/modules/vf-graphql-holochain/resolvers/economicResource.ts
+++ b/modules/vf-graphql-holochain/resolvers/economicResource.ts
@@ -5,7 +5,7 @@
  * @since:   2019-10-31
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ById, ReadParams } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ById, ReadParams, ResourceSpecificationAddress, ProcessSpecificationAddress, AddressableIdentifier } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
@@ -51,20 +51,20 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
       },
     },
     (hasKnowledge ? {
-      conformsTo: async (record: EconomicResource): Promise<ResourceSpecification> => {
-        return (await readResourceSpecification({ address: record.conformsTo})).resourceSpecification
+      conformsTo: async (record: { conformsTo: ResourceSpecificationAddress }): Promise<ResourceSpecification> => {
+        return (await readResourceSpecification({ address: record.conformsTo })).resourceSpecification
       },
 
-      stage: async (record: EconomicResource): Promise<ProcessSpecification> => {
+      stage: async (record: { stage: ProcessSpecificationAddress }): Promise<ProcessSpecification> => {
         return (await readProcessSpecification({ address: record.stage })).processSpecification
       },
 
-      state: async (record: EconomicResource): Promise<Action> => {
+      state: async (record: { state: AddressableIdentifier }): Promise<Action> => {
         return (await readAction({ id: record.state }))
       },
     } : {}),
     (hasMeasurement ? {
-      unitOfEffort: async (record: EconomicResource): Promise<Maybe<Unit>> => {
+      unitOfEffort: async (record: { unitOfEffort: AddressableIdentifier }): Promise<Maybe<Unit>> => {
         if (!record.unitOfEffort) {
           return null
         }

--- a/modules/vf-graphql-holochain/resolvers/economicResource.ts
+++ b/modules/vf-graphql-holochain/resolvers/economicResource.ts
@@ -39,7 +39,7 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
         if (!resources.edges || !resources.edges.length) {
           return null
         }
-        return resources.edges.pop()['node']
+        return resources.edges.pop()!['node']
       },
 
       contains: async (record: EconomicResource): Promise<EconomicResource[]> => {
@@ -60,7 +60,7 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
       },
 
       state: async (record: EconomicResource): Promise<Action> => {
-        return (await readAction({ address: record.state }))
+        return (await readAction({ id: record.state }))
       },
     } : {}),
     (hasMeasurement ? {

--- a/modules/vf-graphql-holochain/resolvers/fulfillment.ts
+++ b/modules/vf-graphql-holochain/resolvers/fulfillment.ts
@@ -27,14 +27,14 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
     {
       fulfills: injectTypename('Commitment', async (record: Fulfillment): Promise<Commitment> => {
         const results = await readCommitments({ params: { fulfilledBy: record.id } })
-        return results.edges.pop()['node']
+        return results.edges.pop()!['node']
       }),
     },
     (hasObservation ? {
       fulfilledBy: injectTypename('EconomicEvent', async (record: Fulfillment): Promise<EconomicEvent> => {
         const associatedId = remapCellId(record.id, record.fulfilledBy)
         const results = await readEvents({ params: { fulfills: associatedId } })
-        return results.edges.pop()['node']
+        return results.edges.pop()!['node']
       }),
     } : {}),
   )

--- a/modules/vf-graphql-holochain/resolvers/fulfillment.ts
+++ b/modules/vf-graphql-holochain/resolvers/fulfillment.ts
@@ -5,20 +5,23 @@
  * @since:   2019-08-27
  */
 
-import { DNAIdMappings, injectTypename, DEFAULT_VF_MODULES, VfModule } from '../types'
+import { DNAIdMappings, injectTypename, DEFAULT_VF_MODULES, VfModule, EconomicEventAddress } from '../types'
 import { mapZomeFn, remapCellId } from '../connection'
 
 import {
   Fulfillment,
   EconomicEvent,
   Commitment,
+  EconomicEventConnection,
+  CommitmentConnection,
 } from '@valueflows/vf-graphql'
+import { CommitmentSearchInput, EconomicEventSearchInput } from './zomeSearchInputTypes'
 
 export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DNAIdMappings, conductorUri: string) => {
   const hasObservation = -1 !== enabledVFModules.indexOf(VfModule.Observation)
 
-  const readEvents = mapZomeFn(dnaConfig, conductorUri, 'observation', 'economic_event_index', 'query_economic_events')
-  const readCommitments = mapZomeFn(dnaConfig, conductorUri, 'planning', 'commitment_index', 'query_commitments')
+  const readEvents = mapZomeFn<EconomicEventSearchInput, EconomicEventConnection>(dnaConfig, conductorUri, 'observation', 'economic_event_index', 'query_economic_events')
+  const readCommitments = mapZomeFn<CommitmentSearchInput, CommitmentConnection>(dnaConfig, conductorUri, 'planning', 'commitment_index', 'query_commitments')
 
   return Object.assign(
     {

--- a/modules/vf-graphql-holochain/resolvers/intent.ts
+++ b/modules/vf-graphql-holochain/resolvers/intent.ts
@@ -58,14 +58,14 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
       },
     } : {}),
     (hasObservation ? {
-      inputOf: async (record: Intent): Promise<Process[]> => {
+      inputOf: async (record: Intent): Promise<Process> => {
         const results = await readProcesses({ params: { intendedInputs: record.id } })
-        return results.edges.pop()['node']
+        return results.edges.pop()!['node']
       },
 
-      outputOf: async (record: Intent): Promise<Process[]> => {
+      outputOf: async (record: Intent): Promise<Process> => {
         const results = await readProcesses({ params: { intendedOutputs: record.id } })
-        return results.edges.pop()['node']
+        return results.edges.pop()!['node']
       },
     } : {}),
     (hasProposal ? {

--- a/modules/vf-graphql-holochain/resolvers/intent.ts
+++ b/modules/vf-graphql-holochain/resolvers/intent.ts
@@ -5,7 +5,7 @@
  * @since:   2019-08-31
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ReadParams, ById } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ReadParams, ById, ProposedIntentAddress, ResourceSpecificationAddress, AddressableIdentifier } from '../types'
 import { extractEdges, mapZomeFn } from '../connection'
 
 import {
@@ -69,16 +69,16 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
       },
     } : {}),
     (hasProposal ? {
-      publishedIn: async (record: Intent): Promise<ProposedIntent[]> => {
+      publishedIn: async (record: { publishedIn: ProposedIntentAddress[] }): Promise<ProposedIntent[]> => {
         return (await Promise.all((record.publishedIn || []).map((address)=>readProposedIntent({address})))).map(extractProposedIntent)
       },
     } : {}),
     (hasKnowledge ? {
-      resourceConformsTo: async (record: Intent): Promise<ResourceSpecification> => {
+      resourceConformsTo: async (record: { resourceConformsTo: ResourceSpecificationAddress }): Promise<ResourceSpecification> => {
         return (await readResourceSpecification({ address: record.resourceConformsTo })).resourceSpecification
       },
 
-      action: async (record: Intent): Promise<Action> => {
+      action: async (record: { action: AddressableIdentifier }): Promise<Action> => {
         return (await readAction({ id: record.action }))
       },
     } : {}),

--- a/modules/vf-graphql-holochain/resolvers/intent.ts
+++ b/modules/vf-graphql-holochain/resolvers/intent.ts
@@ -5,7 +5,7 @@
  * @since:   2019-08-31
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ReadParams, ById } from '../types'
 import { extractEdges, mapZomeFn } from '../connection'
 
 import {
@@ -17,9 +17,14 @@ import {
   ResourceSpecification,
   ProposedIntent,
   Action,
+  SatisfactionConnection,
+  ProcessConnection,
+  ProposedIntentResponse,
+  ResourceSpecificationResponse,
 } from '@valueflows/vf-graphql'
 
 import agentQueries from '../queries/agent'
+import { ProcessSearchInput, SatisfactionSearchInput } from './zomeSearchInputTypes'
 
 const extractProposedIntent = (data): ProposedIntent => data.proposedIntent
 
@@ -29,11 +34,11 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
   const hasObservation = -1 !== enabledVFModules.indexOf(VfModule.Observation)
   const hasProposal = -1 !== enabledVFModules.indexOf(VfModule.Proposal)
 
-  const readSatisfactions = mapZomeFn(dnaConfig, conductorUri, 'planning', 'satisfaction_index', 'query_satisfactions')
-  const readProcesses = mapZomeFn(dnaConfig, conductorUri, 'observation', 'process_index', 'query_processes')
-  const readProposedIntent = mapZomeFn(dnaConfig, conductorUri, 'proposal', 'proposed_intent', 'get_proposed_intent')
-  const readResourceSpecification = mapZomeFn(dnaConfig, conductorUri, 'specification', 'resource_specification', 'get_resource_specification')
-  const readAction = mapZomeFn(dnaConfig, conductorUri, 'specification', 'action', 'get_action')
+  const readSatisfactions = mapZomeFn<SatisfactionSearchInput, SatisfactionConnection>(dnaConfig, conductorUri, 'planning', 'satisfaction_index', 'query_satisfactions')
+  const readProcesses = mapZomeFn<ProcessSearchInput, ProcessConnection>(dnaConfig, conductorUri, 'observation', 'process_index', 'query_processes')
+  const readProposedIntent = mapZomeFn<ReadParams, ProposedIntentResponse>(dnaConfig, conductorUri, 'proposal', 'proposed_intent', 'get_proposed_intent')
+  const readResourceSpecification = mapZomeFn<ReadParams, ResourceSpecificationResponse>(dnaConfig, conductorUri, 'specification', 'resource_specification', 'get_resource_specification')
+  const readAction = mapZomeFn<ById, Action>(dnaConfig, conductorUri, 'specification', 'action', 'get_action')
   const readAgent = agentQueries(dnaConfig, conductorUri)['agent']
 
   return Object.assign(

--- a/modules/vf-graphql-holochain/resolvers/measure.ts
+++ b/modules/vf-graphql-holochain/resolvers/measure.ts
@@ -5,7 +5,7 @@
  * @since:   2019-12-24
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ById } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ById, AddressableIdentifier } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
@@ -19,7 +19,7 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
   const readUnit = mapZomeFn<ById, UnitResponse>(dnaConfig, conductorUri, 'specification', 'unit', 'get_unit')
 
   return {
-    hasUnit: async (record: Measure): Promise<Maybe<Unit>> => {
+    hasUnit: async (record: { hasUnit: AddressableIdentifier }): Promise<Maybe<Unit>> => {
       if (!record.hasUnit) {
         return null
       }

--- a/modules/vf-graphql-holochain/resolvers/measure.ts
+++ b/modules/vf-graphql-holochain/resolvers/measure.ts
@@ -5,17 +5,18 @@
  * @since:   2019-12-24
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ById } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
   Maybe,
   Measure,
   Unit,
+  UnitResponse,
 } from '@valueflows/vf-graphql'
 
 export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const readUnit = mapZomeFn(dnaConfig, conductorUri, 'specification', 'unit', 'get_unit')
+  const readUnit = mapZomeFn<ById, UnitResponse>(dnaConfig, conductorUri, 'specification', 'unit', 'get_unit')
 
   return {
     hasUnit: async (record: Measure): Promise<Maybe<Unit>> => {

--- a/modules/vf-graphql-holochain/resolvers/plan.ts
+++ b/modules/vf-graphql-holochain/resolvers/plan.ts
@@ -13,8 +13,10 @@ import {
   PlanProcessFilterParams,
   Plan,
   Commitment,
-  ProcessConnection
+  ProcessConnection,
+  CommitmentConnection
 } from '@valueflows/vf-graphql'
+import { CommitmentSearchInput, ProcessSearchInput } from './zomeSearchInputTypes'
 
 
 export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DNAIdMappings, conductorUri: string) => {
@@ -22,8 +24,8 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
   const hasObservation = -1 !== enabledVFModules.indexOf(VfModule.Observation)
   const hasPlanning = -1 !== enabledVFModules.indexOf(VfModule.Planning)
 
-  const readProcesses = mapZomeFn(dnaConfig, conductorUri, 'observation', 'process_index', 'query_processes')
-  const queryCommitments = mapZomeFn(dnaConfig, conductorUri, 'planning', 'commitment_index', 'query_commitments')
+  const readProcesses = mapZomeFn<ProcessSearchInput, ProcessConnection>(dnaConfig, conductorUri, 'observation', 'process_index', 'query_processes')
+  const queryCommitments = mapZomeFn<CommitmentSearchInput, CommitmentConnection>(dnaConfig, conductorUri, 'planning', 'commitment_index', 'query_commitments')
 
   return Object.assign(
     (hasObservation ? {

--- a/modules/vf-graphql-holochain/resolvers/process.ts
+++ b/modules/vf-graphql-holochain/resolvers/process.ts
@@ -5,7 +5,7 @@
  * @since:   2019-09-12
  */
 
-import { DNAIdMappings, injectTypename, DEFAULT_VF_MODULES, VfModule, ReadParams } from '../types'
+import { DNAIdMappings, injectTypename, DEFAULT_VF_MODULES, VfModule, ReadParams, ProcessSpecificationAddress } from '../types'
 import { mapZomeFn, extractEdges } from '../connection'
 
 import {
@@ -68,7 +68,7 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
       },
     } : {}),
     (hasKnowledge ? {
-      basedOn: async (record: Process): Promise<ProcessSpecification> => {
+      basedOn: async (record: { basedOn: ProcessSpecificationAddress }): Promise<ProcessSpecification> => {
         return (await readProcessBasedOn({ address: record.basedOn })).processSpecification
       },
     } : {}),

--- a/modules/vf-graphql-holochain/resolvers/process.ts
+++ b/modules/vf-graphql-holochain/resolvers/process.ts
@@ -5,7 +5,7 @@
  * @since:   2019-09-12
  */
 
-import { DNAIdMappings, injectTypename, DEFAULT_VF_MODULES, VfModule } from '../types'
+import { DNAIdMappings, injectTypename, DEFAULT_VF_MODULES, VfModule, ReadParams } from '../types'
 import { mapZomeFn, extractEdges } from '../connection'
 
 import {
@@ -14,19 +14,24 @@ import {
   Commitment,
   Intent,
   ProcessSpecification,
-  Plan
+  Plan,
+  EconomicEventConnection,
+  CommitmentConnection,
+  IntentConnection,
+  ProcessSpecificationResponse
 } from '@valueflows/vf-graphql'
 import planQueries from '../queries/plan'
+import { CommitmentSearchInput, EconomicEventSearchInput, IntentSearchInput } from './zomeSearchInputTypes'
 
 export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DNAIdMappings, conductorUri: string) => {
   const hasKnowledge = -1 !== enabledVFModules.indexOf(VfModule.Knowledge)
   const hasPlanning = -1 !== enabledVFModules.indexOf(VfModule.Planning)
   const hasPlan = -1 !== enabledVFModules.indexOf(VfModule.Plan)
 
-  const readEvents = mapZomeFn(dnaConfig, conductorUri, 'observation', 'economic_event_index', 'query_economic_events')
-  const readCommitments = mapZomeFn(dnaConfig, conductorUri, 'planning', 'commitment_index', 'query_commitments')
-  const readIntents = mapZomeFn(dnaConfig, conductorUri, 'planning', 'intent_index', 'query_intents')
-  const readProcessBasedOn = mapZomeFn(dnaConfig, conductorUri, 'specification', 'process_specification', 'get_process_specification')
+  const readEvents = mapZomeFn<EconomicEventSearchInput, EconomicEventConnection>(dnaConfig, conductorUri, 'observation', 'economic_event_index', 'query_economic_events')
+  const readCommitments = mapZomeFn<CommitmentSearchInput, CommitmentConnection>(dnaConfig, conductorUri, 'planning', 'commitment_index', 'query_commitments')
+  const readIntents = mapZomeFn<IntentSearchInput, IntentConnection>(dnaConfig, conductorUri, 'planning', 'intent_index', 'query_intents')
+  const readProcessBasedOn = mapZomeFn<ReadParams, ProcessSpecificationResponse>(dnaConfig, conductorUri, 'specification', 'process_specification', 'get_process_specification')
   const readPlan = planQueries(dnaConfig, conductorUri)['plan']
 
   return Object.assign(

--- a/modules/vf-graphql-holochain/resolvers/proposal.ts
+++ b/modules/vf-graphql-holochain/resolvers/proposal.ts
@@ -5,7 +5,7 @@
  * @since:   2019-08-27
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ReadParams } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ReadParams, ProposedIntentAddress, AddressableIdentifier } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
@@ -24,11 +24,11 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
   const readProposedIntent = mapZomeFn<ReadParams, ProposedIntentResponse>(dnaConfig, conductorUri, 'proposal', 'proposed_intent', 'get_proposed_intent')
 
   return {
-    publishes: async (record: Proposal): Promise<ProposedIntent[]> => {
+    publishes: async (record: { publishes: ProposedIntentAddress[] }): Promise<ProposedIntent[]> => {
       return (await Promise.all((record.publishes || []).map((address)=>readProposedIntent({address})))).map(extractProposedIntent)
     },
 
-    publishedTo: async (record: Proposal): Promise<ProposedTo[]> => {
+    publishedTo: async (record: { publishedTo: AddressableIdentifier[] }): Promise<ProposedTo[]> => {
       return (await Promise.all((record.publishedTo || []).map((address)=>readProposedTo({address})))).map(extractProposedTo)
     },
   }

--- a/modules/vf-graphql-holochain/resolvers/proposal.ts
+++ b/modules/vf-graphql-holochain/resolvers/proposal.ts
@@ -5,21 +5,23 @@
  * @since:   2019-08-27
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
   Proposal,
   ProposedTo,
   ProposedIntent,
+  ProposedToResponse,
+  ProposedIntentResponse,
 } from '@valueflows/vf-graphql'
 
 const extractProposedTo = (data): ProposedTo => data.proposedTo
 const extractProposedIntent = (data): ProposedIntent => data.proposedIntent
 
 export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DNAIdMappings, conductorUri: string) => {
-  const readProposedTo = mapZomeFn(dnaConfig, conductorUri, 'proposal', 'proposed_to', 'get_proposed_to')
-  const readProposedIntent = mapZomeFn(dnaConfig, conductorUri, 'proposal', 'proposed_intent', 'get_proposed_intent')
+  const readProposedTo = mapZomeFn<ReadParams, ProposedToResponse>(dnaConfig, conductorUri, 'proposal', 'proposed_to', 'get_proposed_to')
+  const readProposedIntent = mapZomeFn<ReadParams, ProposedIntentResponse>(dnaConfig, conductorUri, 'proposal', 'proposed_intent', 'get_proposed_intent')
 
   return {
     publishes: async (record: Proposal): Promise<ProposedIntent[]> => {

--- a/modules/vf-graphql-holochain/resolvers/proposedIntent.ts
+++ b/modules/vf-graphql-holochain/resolvers/proposedIntent.ts
@@ -5,7 +5,7 @@
  * @since:   2019-08-27
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ReadParams } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ReadParams, ProposalAddress, IntentAddress } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
@@ -24,12 +24,12 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
 
   return Object.assign(
     {
-      publishedIn: async (record: ProposedIntent): Promise<Proposal> => {
+      publishedIn: async (record: { publishedIn: ProposalAddress }): Promise<Proposal> => {
         return (await readProposal({address:record.publishedIn})).proposal
       },
     },
     (hasPlanning ? {
-      publishes: async (record: ProposedIntent): Promise<Intent> => {
+      publishes: async (record: { publishes: IntentAddress }): Promise<Intent> => {
         return (await readIntent({address:record.publishes})).intent
       },
     } : {}),

--- a/modules/vf-graphql-holochain/resolvers/proposedIntent.ts
+++ b/modules/vf-graphql-holochain/resolvers/proposedIntent.ts
@@ -5,20 +5,22 @@
  * @since:   2019-08-27
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
   Proposal,
   Intent,
   ProposedIntent,
+  ProposalResponse,
+  IntentResponse,
 } from '@valueflows/vf-graphql'
 
 export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DNAIdMappings, conductorUri: string) => {
   const hasPlanning = -1 !== enabledVFModules.indexOf(VfModule.Planning)
 
-  const readProposal = mapZomeFn(dnaConfig, conductorUri, 'proposal', 'proposal', 'get_proposal')
-  const readIntent = mapZomeFn(dnaConfig, conductorUri, 'planning', 'intent', 'get_intent')
+  const readProposal = mapZomeFn<ReadParams, ProposalResponse>(dnaConfig, conductorUri, 'proposal', 'proposal', 'get_proposal')
+  const readIntent = mapZomeFn<ReadParams, IntentResponse>(dnaConfig, conductorUri, 'planning', 'intent', 'get_intent')
 
   return Object.assign(
     {

--- a/modules/vf-graphql-holochain/resolvers/proposedTo.ts
+++ b/modules/vf-graphql-holochain/resolvers/proposedTo.ts
@@ -5,7 +5,7 @@
  * @since:   2019-08-27
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ReadParams } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ReadParams, ProposalAddress, AgentAddress } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
@@ -25,12 +25,12 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
 
   return Object.assign(
     {
-      proposed: async (record: ProposedTo): Promise<Proposal> => {
+      proposed: async (record: { proposed: ProposalAddress }): Promise<Proposal> => {
         return (await readProposal({address:record.proposed})).proposal
       },
     },
     (hasAgent ? {
-      proposedTo: async (record: ProposedTo): Promise<Agent> => {
+      proposedTo: async (record: { proposedTo: AgentAddress}): Promise<Agent> => {
         return readAgent(record, { id: record.proposedTo })
       },
     } : {}),

--- a/modules/vf-graphql-holochain/resolvers/proposedTo.ts
+++ b/modules/vf-graphql-holochain/resolvers/proposedTo.ts
@@ -5,13 +5,14 @@
  * @since:   2019-08-27
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ReadParams } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
   Proposal,
   ProposedTo,
   Agent,
+  ProposalResponse,
 } from '@valueflows/vf-graphql'
 
 import agentQueries from '../queries/agent'
@@ -19,7 +20,7 @@ import agentQueries from '../queries/agent'
 export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DNAIdMappings, conductorUri: string) => {
   const hasAgent = -1 !== enabledVFModules.indexOf(VfModule.Agent)
 
-  const readProposal = mapZomeFn(dnaConfig, conductorUri, 'proposal', 'proposal', 'get_proposal')
+  const readProposal = mapZomeFn<ReadParams, ProposalResponse>(dnaConfig, conductorUri, 'proposal', 'proposal', 'get_proposal')
   const readAgent = agentQueries(dnaConfig, conductorUri)['agent']
 
   return Object.assign(

--- a/modules/vf-graphql-holochain/resolvers/resourceSpecification.ts
+++ b/modules/vf-graphql-holochain/resolvers/resourceSpecification.ts
@@ -5,7 +5,7 @@
  * @since:   2019-08-27
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ById } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ById, AddressableIdentifier } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
@@ -31,7 +31,7 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
       },
     } : {}),
     (hasMeasurement ? {
-      defaultUnitOfEffort: async (record: ResourceSpecification): Promise<Maybe<Unit>> => {
+      defaultUnitOfEffort: async (record: { defaultUnitOfEffort: AddressableIdentifier }): Promise<Maybe<Unit>> => {
         if (!record.defaultUnitOfEffort) {
           return null
         }

--- a/modules/vf-graphql-holochain/resolvers/resourceSpecification.ts
+++ b/modules/vf-graphql-holochain/resolvers/resourceSpecification.ts
@@ -5,7 +5,7 @@
  * @since:   2019-08-27
  */
 
-import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule } from '../types'
+import { DNAIdMappings, DEFAULT_VF_MODULES, VfModule, ById } from '../types'
 import { mapZomeFn } from '../connection'
 
 import {
@@ -13,14 +13,16 @@ import {
   EconomicResourceConnection,
   ResourceSpecification,
   Unit,
+  UnitResponse,
 } from '@valueflows/vf-graphql'
+import { EconomicResourceSearchInput } from './zomeSearchInputTypes'
 
 export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DNAIdMappings, conductorUri: string) => {
   const hasMeasurement = -1 !== enabledVFModules.indexOf(VfModule.Measurement)
   const hasObservation = -1 !== enabledVFModules.indexOf(VfModule.Observation)
 
-  const queryResources = mapZomeFn(dnaConfig, conductorUri, 'observation', 'economic_resource_index', 'query_economic_resources')
-  const readUnit = mapZomeFn(dnaConfig, conductorUri, 'specification', 'unit', 'get_unit')
+  const queryResources = mapZomeFn<EconomicResourceSearchInput, EconomicResourceConnection>(dnaConfig, conductorUri, 'observation', 'economic_resource_index', 'query_economic_resources')
+  const readUnit = mapZomeFn<ById, UnitResponse>(dnaConfig, conductorUri, 'specification', 'unit', 'get_unit')
 
   return Object.assign(
     (hasObservation ? {

--- a/modules/vf-graphql-holochain/resolvers/satisfaction.ts
+++ b/modules/vf-graphql-holochain/resolvers/satisfaction.ts
@@ -54,7 +54,7 @@ export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DN
 
     satisfies: async (record: Satisfaction): Promise<Intent> => {
       const results = await readIntents({ params: { satisfiedBy: record.id } })
-      return results.edges.pop()['node']
+      return results.edges.pop()!['node']
     },
   }
 }

--- a/modules/vf-graphql-holochain/resolvers/satisfaction.ts
+++ b/modules/vf-graphql-holochain/resolvers/satisfaction.ts
@@ -12,7 +12,11 @@ import {
   Satisfaction,
   EventOrCommitment,
   Intent,
+  EconomicEventConnection,
+  CommitmentConnection,
+  IntentConnection,
 } from '@valueflows/vf-graphql'
+import { CommitmentSearchInput, EconomicEventSearchInput, IntentSearchInput } from './zomeSearchInputTypes'
 
 async function extractRecordsOrFail (query): Promise<any> {
   const val = await query
@@ -25,9 +29,9 @@ async function extractRecordsOrFail (query): Promise<any> {
 export default (enabledVFModules: VfModule[] = DEFAULT_VF_MODULES, dnaConfig: DNAIdMappings, conductorUri: string) => {
   const hasObservation = -1 !== enabledVFModules.indexOf(VfModule.Observation)
 
-  const readEvents = mapZomeFn(dnaConfig, conductorUri, 'observation', 'economic_event_index', 'query_economic_events')
-  const readCommitments = mapZomeFn(dnaConfig, conductorUri, 'planning', 'commitment_index', 'query_commitments')
-  const readIntents = mapZomeFn(dnaConfig, conductorUri, 'planning', 'intent_index', 'query_intents')
+  const readEvents = mapZomeFn<EconomicEventSearchInput, EconomicEventConnection>(dnaConfig, conductorUri, 'observation', 'economic_event_index', 'query_economic_events')
+  const readCommitments = mapZomeFn<CommitmentSearchInput, CommitmentConnection>(dnaConfig, conductorUri, 'planning', 'commitment_index', 'query_commitments')
+  const readIntents = mapZomeFn<IntentSearchInput, IntentConnection>(dnaConfig, conductorUri, 'planning', 'intent_index', 'query_intents')
 
   return {
     satisfiedBy: async (record: Satisfaction): Promise<EventOrCommitment> => {

--- a/modules/vf-graphql-holochain/resolvers/zomeSearchInputTypes.ts
+++ b/modules/vf-graphql-holochain/resolvers/zomeSearchInputTypes.ts
@@ -1,0 +1,70 @@
+import { AgentAddress, AgreementAddress, CommitmentAddress, EconomicEventAddress, EconomicResourceAddress, FulfillmentAddress, IntentAddress, PlanAddress, ProcessAddress, ProposedIntentAddress, ResourceSpecificationAddress, SatisfactionAddress } from "../types";
+
+interface SearchInput<QueryParamType> {
+  params: QueryParamType,
+}
+
+export type CommitmentSearchInput = SearchInput<CommitmentQueryParam>
+export type EconomicEventSearchInput = SearchInput<EconomicEventQueryParams>
+export type FulfillmentSearchInput = SearchInput<FulfillmentQueryParams>
+export type SatisfactionSearchInput = SearchInput<SatisfactionQueryParams>
+export type ProcessSearchInput = SearchInput<ProcessQueryParams>
+export type ResourceSpecificationSearchInput = SearchInput<ResourceSpecificationQueryParams>
+export type EconomicResourceSearchInput = SearchInput<EconomicResourceQueryParams>
+export type IntentSearchInput = SearchInput<IntentQueryParams>
+
+interface CommitmentQueryParam {
+    inputOf?: ProcessAddress,
+    outputOf?: ProcessAddress,
+    fulfilledBy?: FulfillmentAddress,
+    satisfies?: SatisfactionAddress,
+    clauseOf?: AgreementAddress,
+    independentDemandOf?: PlanAddress,
+    plannedWithin?: PlanAddress,
+}
+
+interface EconomicEventQueryParams {
+    inputOf?: ProcessAddress,
+    outputOf?: ProcessAddress,
+    satisfies?: IntentAddress,
+    fulfills?: CommitmentAddress,
+    realizationOf?: AgreementAddress,
+    affects?: EconomicResourceAddress,
+}
+
+interface FulfillmentQueryParams {
+    fulfills?: CommitmentAddress,
+    fulfilledBy?: EconomicEventAddress,
+}
+interface SatisfactionQueryParams {
+    satisfies?: IntentAddress,
+    satisfiedBy?: CommitmentAddress,
+}
+
+interface ProcessQueryParams {
+    inputs?: EconomicEventAddress,
+    outputs?: EconomicEventAddress,
+    unplannedEconomicEvents?: EconomicEventAddress,
+    committedInputs?: CommitmentAddress,
+    committedOutputs?: CommitmentAddress,
+    intendedInputs?: IntentAddress,
+    intendedOutputs?: IntentAddress,
+    workingAgents?: AgentAddress,
+    plannedWithin?: PlanAddress,
+}
+
+interface ResourceSpecificationQueryParams {
+    conformingResources?: EconomicResourceAddress,
+}
+interface EconomicResourceQueryParams {
+    contains?: EconomicResourceAddress,
+    containedIn?: EconomicResourceAddress,
+    conformsTo?: ResourceSpecificationAddress,
+    affectedBy?: EconomicEventAddress,
+}
+interface IntentQueryParams {
+    inputOf?: ProcessAddress,
+    outputOf?: ProcessAddress,
+    satisfiedBy?: SatisfactionAddress,
+    proposedIn?: ProposedIntentAddress,
+}

--- a/modules/vf-graphql-holochain/types.ts
+++ b/modules/vf-graphql-holochain/types.ts
@@ -5,7 +5,7 @@
  * @since:   2019-05-20
  */
 
-import { AppSignalCb, CellId } from '@holochain/client'
+import { AppSignalCb, CellId, HeaderHash } from '@holochain/client'
 import { IResolvers } from '@graphql-tools/utils'
 import { GraphQLScalarType } from 'graphql'
 import { Kind } from 'graphql/language'
@@ -53,6 +53,35 @@ export interface ExtensionOptions {
   // parts of the Holo-REA core behaviour!
   extensionResolvers?: IResolvers,
 }
+
+// types that serialize for rust zome calls
+// start of section
+export interface ReadParams {
+  address: AddressableIdentifier,
+}
+export interface ById {
+  id: AddressableIdentifier,
+}
+
+export type AddressableIdentifier = string
+export type CommitmentAddress = AddressableIdentifier
+export type ProcessAddress = AddressableIdentifier
+export type FulfillmentAddress = AddressableIdentifier
+export type SatisfactionAddress = AddressableIdentifier
+export type AgreementAddress = AddressableIdentifier
+export type PlanAddress = AddressableIdentifier
+export type ProposalAddress = AddressableIdentifier
+export type IntentAddress = AddressableIdentifier
+export type AgentAddress = AddressableIdentifier
+export type EconomicResourceAddress = AddressableIdentifier
+export type EconomicEventAddress = AddressableIdentifier
+export type ResourceSpecificationAddress = AddressableIdentifier
+export type ProposedIntentAddress = AddressableIdentifier
+
+export interface ByRevision {
+  revisionId: string
+}
+// end of section
 
 export type APIOptions = ResolverOptions & ExtensionOptions
 

--- a/modules/vf-graphql-holochain/types.ts
+++ b/modules/vf-graphql-holochain/types.ts
@@ -77,6 +77,7 @@ export type EconomicResourceAddress = AddressableIdentifier
 export type EconomicEventAddress = AddressableIdentifier
 export type ResourceSpecificationAddress = AddressableIdentifier
 export type ProposedIntentAddress = AddressableIdentifier
+export type ProcessSpecificationAddress = AddressableIdentifier
 
 export interface ByRevision {
   revisionId: string

--- a/test/core-architecture/test_record_delete.js
+++ b/test/core-architecture/test_record_delete.js
@@ -40,7 +40,7 @@ runner.registerScenario('record deletion API', async (s, t) => {
   t.deepEqual(readResp.commitment.id, commitmentId, 'record retrievable')
 
   // perform deletion
-  const delResp = await planning.call('commitment', 'delete_commitment', { address: commitmentResponse.commitment.revisionId })
+  const delResp = await planning.call('commitment', 'delete_commitment', { revisionId: commitmentResponse.commitment.revisionId })
   t.ok(delResp, 'record deleted successfully')
   await s.consistency()
 
@@ -78,7 +78,7 @@ runner2.registerScenario('Cannot delete records of a different type via zome API
 
   // attempt to delete commitment via satisfaction deletion API
   try {
-    await planning.call('satisfaction', 'delete_satisfaction', { address: commitmentResponse.commitment.revisionId })
+    await planning.call('satisfaction', 'delete_satisfaction', { revisionId: commitmentResponse.commitment.revisionId })
   } catch (err) {
     t.ok(err.data.data.includes('Could not convert entry to requested type'), 'records not deleteable via IDs of incorrect type')
   }

--- a/test/core-architecture/test_record_links_cross_zome.js
+++ b/test/core-architecture/test_record_links_cross_zome.js
@@ -192,7 +192,7 @@ runner2.registerScenario('removing records with linked local indexes clears them
   t.deepEqual(readResponse && readResponse.edges[0] && readResponse.edges[0].node && readResponse.edges[0].node.id, processId, 'reciprocal query index OK')
 
   // SCENARIO: wipe associated record
-  const delResp = await observation.call('economic_event', 'delete_economic_event', { address: iEventRev })
+  const delResp = await observation.call('economic_event', 'delete_economic_event', { revisionId: iEventRev })
   t.ok(delResp, 'input record deleted')
   await s.consistency()
 

--- a/test/core-architecture/test_record_links_remove_cross_dna.js
+++ b/test/core-architecture/test_record_links_remove_cross_dna.js
@@ -66,7 +66,7 @@ runner.registerScenario('removing records with linked remote indexes clears them
 
 
   // SCENARIO: wipe associated record
-  await planning.call('intent', 'delete_intent', { address: iIntentRevisionId })
+  await planning.call('intent', 'delete_intent', { revisionId: iIntentRevisionId })
   await s.consistency()
 
   // ASSERT: test forward link field

--- a/test/economic-resource/resource_logic.js
+++ b/test/economic-resource/resource_logic.js
@@ -26,7 +26,7 @@ runner.registerScenario('EconomicResource & EconomicEvent record interactions', 
   const processSpecification = {
     name: 'test process specification A',
   }
-  const psResp = await specification.call('process_specification', 'create_process_specification', { process_specification: processSpecification })
+  const psResp = await specification.call('process_specification', 'create_process_specification', { processSpecification: processSpecification })
   await s.consistency()
   t.ok(psResp.processSpecification && psResp.processSpecification.id, 'process spec 1 created successfully')
   const pSpecId = psResp.processSpecification.id
@@ -34,7 +34,7 @@ runner.registerScenario('EconomicResource & EconomicEvent record interactions', 
   const processSpecification2 = {
     name: 'test process specification B',
   }
-  const psResp2 = await specification.call('process_specification', 'create_process_specification', { process_specification: processSpecification2 })
+  const psResp2 = await specification.call('process_specification', 'create_process_specification', { processSpecification: processSpecification2 })
   await s.consistency()
   t.ok(psResp2.processSpecification && psResp2.processSpecification.id, 'process spec 2 created successfully')
   const pSpecId2 = psResp2.processSpecification.id
@@ -43,7 +43,7 @@ runner.registerScenario('EconomicResource & EconomicEvent record interactions', 
     name: 'test resource specification',
     defaultUnitOfEffort: resourceUnitId,
   }
-  const rsResp2 = await specification.call('resource_specification', 'create_resource_specification', { resource_specification: resourceSpecification })
+  const rsResp2 = await specification.call('resource_specification', 'create_resource_specification', { resourceSpecification: resourceSpecification })
   await s.consistency()
   t.ok(rsResp2.resourceSpecification && rsResp2.resourceSpecification.id, 'resource spec created successfully')
   const resourceSpecificationId = rsResp2.resourceSpecification.id

--- a/zomes/rea_agreement/rpc/src/lib.rs
+++ b/zomes/rea_agreement/rpc/src/lib.rs
@@ -16,6 +16,7 @@ pub use vf_attributes_hdk::{
     DateTime,
     FixedOffset,
     ByHeader, HeaderHash,
+    ByRevision,
 };
 
 //---------------- EXTERNAL RECORD STRUCTURE ----------------

--- a/zomes/rea_agreement/zome/src/lib.rs
+++ b/zomes/rea_agreement/zome/src/lib.rs
@@ -58,6 +58,6 @@ fn update_agreement(UpdateParams { agreement }: UpdateParams) -> ExternResult<Re
 }
 
 #[hdk_extern]
-fn delete_agreement(ByHeader { address }: ByHeader) -> ExternResult<bool> {
-    Ok(handle_delete_agreement(address)?)
+fn delete_agreement(ByRevision { revision_id }: ByRevision) -> ExternResult<bool> {
+    Ok(handle_delete_agreement(revision_id)?)
 }

--- a/zomes/rea_agreement/zome/src/lib.rs
+++ b/zomes/rea_agreement/zome/src/lib.rs
@@ -28,6 +28,7 @@ fn entry_defs(_: ()) -> ExternResult<EntryDefsCallbackResult> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct CreateParams {
     pub agreement: CreateRequest,
 }
@@ -48,6 +49,7 @@ fn get_agreement(ReadParams { address }: ReadParams) -> ExternResult<ResponseDat
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct UpdateParams {
     pub agreement: UpdateRequest,
 }

--- a/zomes/rea_commitment/rpc/src/lib.rs
+++ b/zomes/rea_commitment/rpc/src/lib.rs
@@ -11,7 +11,7 @@ use holochain_serialized_bytes::prelude::*;
 use serde_maybe_undefined::{MaybeUndefined, default_false};
 use vf_measurement::QuantityValue;
 pub use vf_attributes_hdk::{
-    HeaderHash, ByHeader,
+    HeaderHash, ByHeader, ByRevision,
     ActionId,
     DateTime, FixedOffset,
     ExternalURL,

--- a/zomes/rea_commitment/zome/src/lib.rs
+++ b/zomes/rea_commitment/zome/src/lib.rs
@@ -67,6 +67,7 @@ fn entry_defs(_: ()) -> ExternResult<EntryDefsCallbackResult> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct CreateParams {
     pub commitment: CreateRequest,
 }
@@ -87,6 +88,7 @@ fn get_commitment(ByAddress { address }: ByAddress) -> ExternResult<ResponseData
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct UpdateParams {
     pub commitment: UpdateRequest,
 }

--- a/zomes/rea_commitment/zome/src/lib.rs
+++ b/zomes/rea_commitment/zome/src/lib.rs
@@ -97,6 +97,6 @@ fn update_commitment(UpdateParams { commitment }: UpdateParams) -> ExternResult<
 }
 
 #[hdk_extern]
-fn delete_commitment(ByHeader { address }: ByHeader) -> ExternResult<bool> {
-    Ok(handle_delete_commitment(address)?)
+fn delete_commitment(ByRevision { revision_id }: ByRevision) -> ExternResult<bool> {
+    Ok(handle_delete_commitment(revision_id)?)
 }

--- a/zomes/rea_economic_event/rpc/src/lib.rs
+++ b/zomes/rea_economic_event/rpc/src/lib.rs
@@ -330,6 +330,7 @@ impl<'a> UpdateRequest {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UpdateParams {
     pub event: UpdateRequest,
 }

--- a/zomes/rea_economic_event/rpc/src/lib.rs
+++ b/zomes/rea_economic_event/rpc/src/lib.rs
@@ -12,7 +12,7 @@ use serde_maybe_undefined::MaybeUndefined;
 use vf_measurement::QuantityValue;
 use hdk_relay_pagination::PageInfo;
 pub use vf_attributes_hdk::{
-    HeaderHash, ByAddress, ByHeader,
+    HeaderHash, ByAddress, ByHeader, ByRevision,
     EconomicEventAddress,
     EconomicResourceAddress,
     ActionId,

--- a/zomes/rea_economic_event/zome_api/src/lib.rs
+++ b/zomes/rea_economic_event/zome_api/src/lib.rs
@@ -42,8 +42,8 @@ macro_rules! declare_economic_event_zome_api {
         }
 
         #[hdk_extern]
-        fn delete_economic_event(ByHeader { address }: ByHeader) -> ExternResult<bool> {
-            Ok(<$zome_api>::delete_economic_event(address)?)
+        fn delete_economic_event(ByRevision { revision_id }: ByRevision) -> ExternResult<bool> {
+            Ok(<$zome_api>::delete_economic_event(revision_id)?)
         }
 
         #[hdk_extern]

--- a/zomes/rea_economic_resource/rpc/src/lib.rs
+++ b/zomes/rea_economic_resource/rpc/src/lib.rs
@@ -87,6 +87,7 @@ impl<'a> UpdateRequest {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UpdateParams {
     pub resource: UpdateRequest,
 }

--- a/zomes/rea_fulfillment/rpc/src/lib.rs
+++ b/zomes/rea_fulfillment/rpc/src/lib.rs
@@ -19,11 +19,13 @@ pub use vf_attributes_hdk::{
 /// Toplevel I/O structs for WASM API
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateParams {
     pub fulfillment: CreateRequest,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UpdateParams {
     pub fulfillment: UpdateRequest,
 }

--- a/zomes/rea_fulfillment/rpc/src/lib.rs
+++ b/zomes/rea_fulfillment/rpc/src/lib.rs
@@ -11,7 +11,7 @@ use holochain_serialized_bytes::prelude::*;
 use serde_maybe_undefined::{MaybeUndefined};
 use vf_measurement::QuantityValue;
 pub use vf_attributes_hdk::{
-    HeaderHash, ByHeader, ByAddress,
+    HeaderHash, ByHeader, ByAddress, ByRevision,
     EconomicEventAddress,
     CommitmentAddress,
 };

--- a/zomes/rea_fulfillment/zome_observation/src/lib.rs
+++ b/zomes/rea_fulfillment/zome_observation/src/lib.rs
@@ -53,6 +53,6 @@ fn fulfillment_updated(UpdateParams { fulfillment }: UpdateParams) -> ExternResu
 }
 
 #[hdk_extern]
-fn fulfillment_deleted(ByHeader { address }: ByHeader) -> ExternResult<bool> {
-    Ok(handle_delete_fulfillment(address)?)
+fn fulfillment_deleted(ByRevision { revision_id }: ByRevision) -> ExternResult<bool> {
+    Ok(handle_delete_fulfillment(revision_id)?)
 }

--- a/zomes/rea_fulfillment/zome_planning/src/lib.rs
+++ b/zomes/rea_fulfillment/zome_planning/src/lib.rs
@@ -52,6 +52,6 @@ fn update_fulfillment(UpdateParams { fulfillment }: UpdateParams) -> ExternResul
 }
 
 #[hdk_extern]
-fn delete_fulfillment(ByHeader { address }: ByHeader) -> ExternResult<bool> {
-    Ok(handle_delete_fulfillment(address)?)
+fn delete_fulfillment(ByRevision { revision_id }: ByRevision) -> ExternResult<bool> {
+    Ok(handle_delete_fulfillment(revision_id)?)
 }

--- a/zomes/rea_intent/rpc/src/lib.rs
+++ b/zomes/rea_intent/rpc/src/lib.rs
@@ -21,7 +21,7 @@ pub use vf_attributes_hdk::{
     SatisfactionAddress,
     LocationAddress,
     ProposedIntentAddress,
-    HeaderHash, ByHeader,
+    HeaderHash, ByHeader, ByRevision,
 };
 
 //---------------- EXTERNAL RECORD STRUCTURE ----------------

--- a/zomes/rea_intent/zome/src/lib.rs
+++ b/zomes/rea_intent/zome/src/lib.rs
@@ -63,6 +63,7 @@ fn entry_defs(_: ()) -> ExternResult<EntryDefsCallbackResult> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct CreateParams {
     pub intent: CreateRequest,
 }
@@ -86,6 +87,7 @@ fn get_intent(ByAddress { address }: ByAddress) -> ExternResult<ResponseData> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct UpdateParams {
     pub intent: UpdateRequest,
 }

--- a/zomes/rea_intent/zome/src/lib.rs
+++ b/zomes/rea_intent/zome/src/lib.rs
@@ -96,6 +96,6 @@ fn update_intent(UpdateParams { intent }: UpdateParams) -> ExternResult<Response
 }
 
 #[hdk_extern]
-fn delete_intent(ByHeader { address }: ByHeader) -> ExternResult<bool> {
-    Ok(handle_delete_intent(address)?)
+fn delete_intent(ByRevision { revision_id }: ByRevision) -> ExternResult<bool> {
+    Ok(handle_delete_intent(revision_id)?)
 }

--- a/zomes/rea_plan/rpc/src/lib.rs
+++ b/zomes/rea_plan/rpc/src/lib.rs
@@ -16,7 +16,7 @@ pub use vf_attributes_hdk::{
     EconomicEventAddress,
     DateTime,
     FixedOffset,
-    ByHeader, HeaderHash,
+    ByHeader, HeaderHash, ByRevision,
 };
 
 //---------------- EXTERNAL RECORD STRUCTURE ----------------

--- a/zomes/rea_plan/zome/src/lib.rs
+++ b/zomes/rea_plan/zome/src/lib.rs
@@ -58,6 +58,6 @@ fn update_plan(UpdateParams { plan }: UpdateParams) -> ExternResult<ResponseData
 }
 
 #[hdk_extern]
-fn delete_plan(ByHeader { address }: ByHeader) -> ExternResult<bool> {
-    Ok(handle_delete_plan(address)?)
+fn delete_plan(ByRevision { revision_id }: ByRevision) -> ExternResult<bool> {
+    Ok(handle_delete_plan(revision_id)?)
 }

--- a/zomes/rea_plan/zome/src/lib.rs
+++ b/zomes/rea_plan/zome/src/lib.rs
@@ -28,6 +28,7 @@ fn entry_defs(_: ()) -> ExternResult<EntryDefsCallbackResult> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct CreateParams {
     pub plan: CreateRequest,
 }
@@ -48,6 +49,7 @@ fn get_plan(ReadParams { address }: ReadParams) -> ExternResult<ResponseData> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct UpdateParams {
     pub plan: UpdateRequest,
 }

--- a/zomes/rea_process/rpc/src/lib.rs
+++ b/zomes/rea_process/rpc/src/lib.rs
@@ -8,7 +8,7 @@ use serde_maybe_undefined::{
     default_false,
 };
 pub use vf_attributes_hdk::{
-    HeaderHash, ByHeader,
+    HeaderHash, ByHeader, ByRevision,
     ProcessAddress,
     DateTime, FixedOffset,
     ExternalURL,

--- a/zomes/rea_process/zome/src/lib.rs
+++ b/zomes/rea_process/zome/src/lib.rs
@@ -29,6 +29,7 @@ fn entry_defs(_: ()) -> ExternResult<EntryDefsCallbackResult> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct CreateParams {
     pub process: CreateRequest,
 }
@@ -49,6 +50,7 @@ fn get_process(ReadParams { address }: ReadParams) -> ExternResult<ResponseData>
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct UpdateParams {
     pub process: UpdateRequest,
 }

--- a/zomes/rea_process/zome/src/lib.rs
+++ b/zomes/rea_process/zome/src/lib.rs
@@ -59,6 +59,6 @@ fn update_process(UpdateParams { process }: UpdateParams) -> ExternResult<Respon
 }
 
 #[hdk_extern]
-fn delete_process(ByHeader { address }: ByHeader) -> ExternResult<bool> {
-    Ok(handle_delete_process(PROCESS_ENTRY_TYPE, address)?)
+fn delete_process(ByRevision { revision_id }: ByRevision) -> ExternResult<bool> {
+    Ok(handle_delete_process(PROCESS_ENTRY_TYPE, revision_id)?)
 }

--- a/zomes/rea_process_specification/rpc/src/lib.rs
+++ b/zomes/rea_process_specification/rpc/src/lib.rs
@@ -9,7 +9,7 @@
 use holochain_serialized_bytes::prelude::*;
 use serde_maybe_undefined::MaybeUndefined;
 pub use vf_attributes_hdk::{
-    HeaderHash, ByAddress, ByHeader,
+    HeaderHash, ByAddress, ByHeader, ByRevision,
     ProcessSpecificationAddress,
 };
 

--- a/zomes/rea_process_specification/rpc/src/lib.rs
+++ b/zomes/rea_process_specification/rpc/src/lib.rs
@@ -16,11 +16,13 @@ pub use vf_attributes_hdk::{
 // toplevel I/O structs for WASM API
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateParams {
     pub process_specification: CreateRequest,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UpdateParams {
     pub process_specification: UpdateRequest,
 }

--- a/zomes/rea_process_specification/zome/src/lib.rs
+++ b/zomes/rea_process_specification/zome/src/lib.rs
@@ -44,6 +44,6 @@ fn update_process_specification(UpdateParams { process_specification }: UpdatePa
 }
 
 #[hdk_extern]
-fn delete_process_specification(ByHeader { address }: ByHeader) -> ExternResult<bool> {
-    Ok(handle_delete_process_specification(address)?)
+fn delete_process_specification(ByRevision { revision_id }: ByRevision) -> ExternResult<bool> {
+    Ok(handle_delete_process_specification(revision_id)?)
 }

--- a/zomes/rea_proposal/rpc/src/lib.rs
+++ b/zomes/rea_proposal/rpc/src/lib.rs
@@ -9,7 +9,7 @@
 use holochain_serialized_bytes::prelude::*;
 use serde_maybe_undefined::MaybeUndefined;
 pub use vf_attributes_hdk::{
-    HeaderHash, ByAddress, ByHeader,
+    HeaderHash, ByAddress, ByHeader, ByRevision,
     ProposalAddress, ProposedIntentAddress, ProposedToAddress,
     DateTime, FixedOffset,
 };

--- a/zomes/rea_proposal/rpc/src/lib.rs
+++ b/zomes/rea_proposal/rpc/src/lib.rs
@@ -17,11 +17,13 @@ pub use vf_attributes_hdk::{
 /// Toplevel I/O structs for WASM API
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateParams {
     pub proposal: CreateRequest,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UpdateParams {
     pub proposal: UpdateRequest,
 }

--- a/zomes/rea_proposal/zome/src/lib.rs
+++ b/zomes/rea_proposal/zome/src/lib.rs
@@ -44,6 +44,6 @@ fn update_proposal(UpdateParams { proposal }: UpdateParams) -> ExternResult<Resp
 }
 
 #[hdk_extern]
-fn delete_proposal(ByHeader { address }: ByHeader) -> ExternResult<bool> {
-    Ok(handle_delete_proposal(address)?)
+fn delete_proposal(ByRevision { revision_id }: ByRevision) -> ExternResult<bool> {
+    Ok(handle_delete_proposal(revision_id)?)
 }

--- a/zomes/rea_proposed_intent/rpc/src/lib.rs
+++ b/zomes/rea_proposed_intent/rpc/src/lib.rs
@@ -38,6 +38,7 @@ pub struct ResponseData {
 /// Toplevel I/O structs for WASM API
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateParams {
     pub proposed_intent: CreateRequest,
 }

--- a/zomes/rea_proposed_intent/rpc/src/lib.rs
+++ b/zomes/rea_proposed_intent/rpc/src/lib.rs
@@ -8,7 +8,7 @@
  */
 use holochain_serialized_bytes::prelude::*;
 pub use vf_attributes_hdk::{
-    HeaderHash, ByAddress, ByHeader,
+    HeaderHash, ByAddress, ByHeader, ByRevision,
     ProposedIntentAddress, IntentAddress, ProposalAddress,
 };
 

--- a/zomes/rea_proposed_intent/zome/src/lib.rs
+++ b/zomes/rea_proposed_intent/zome/src/lib.rs
@@ -46,6 +46,6 @@ fn get_proposed_intent(ByAddress { address }: ByAddress<ProposedIntentAddress>) 
 }
 
 #[hdk_extern]
-fn delete_proposed_intent(ByHeader { address }: ByHeader) -> ExternResult<bool> {
-    Ok(handle_delete_proposed_intent(&address)?)
+fn delete_proposed_intent(ByRevision { revision_id }: ByRevision) -> ExternResult<bool> {
+    Ok(handle_delete_proposed_intent(&revision_id)?)
 }

--- a/zomes/rea_proposed_to/rpc/src/lib.rs
+++ b/zomes/rea_proposed_to/rpc/src/lib.rs
@@ -8,7 +8,7 @@
  */
 use holochain_serialized_bytes::prelude::*;
 pub use vf_attributes_hdk::{
-    HeaderHash, ByAddress, ByHeader,
+    HeaderHash, ByAddress, ByHeader, ByRevision,
     ProposedToAddress, AgentAddress, ProposalAddress,
 };
 

--- a/zomes/rea_proposed_to/rpc/src/lib.rs
+++ b/zomes/rea_proposed_to/rpc/src/lib.rs
@@ -15,6 +15,7 @@ pub use vf_attributes_hdk::{
 /// Toplevel I/O structs for WASM API
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateParams {
     pub proposed_to: CreateRequest,
 }

--- a/zomes/rea_proposed_to/zome/src/lib.rs
+++ b/zomes/rea_proposed_to/zome/src/lib.rs
@@ -39,6 +39,6 @@ fn get_proposed_to(ByAddress { address }: ByAddress<ProposedToAddress>) -> Exter
 }
 
 #[hdk_extern]
-fn delete_proposed_to(ByHeader { address }: ByHeader) -> ExternResult<bool> {
-    Ok(handle_delete_proposed_to(&address)?)
+fn delete_proposed_to(ByRevision { revision_id }: ByRevision) -> ExternResult<bool> {
+    Ok(handle_delete_proposed_to(&revision_id)?)
 }

--- a/zomes/rea_resource_specification/rpc/src/lib.rs
+++ b/zomes/rea_resource_specification/rpc/src/lib.rs
@@ -19,11 +19,13 @@ pub use vf_attributes_hdk::{
 // toplevel I/O structs for WASM API
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateParams {
     pub resource_specification: CreateRequest,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UpdateParams {
     pub resource_specification: UpdateRequest,
 }

--- a/zomes/rea_resource_specification/rpc/src/lib.rs
+++ b/zomes/rea_resource_specification/rpc/src/lib.rs
@@ -14,6 +14,7 @@ pub use vf_attributes_hdk::{
     EconomicResourceAddress,
     ExternalURL,
     UnitId,
+    ByRevision,
 };
 
 // toplevel I/O structs for WASM API

--- a/zomes/rea_resource_specification/zome/src/lib.rs
+++ b/zomes/rea_resource_specification/zome/src/lib.rs
@@ -44,6 +44,6 @@ fn update_resource_specification(UpdateParams { resource_specification }: Update
 }
 
 #[hdk_extern]
-fn delete_resource_specification(ByHeader { address }: ByHeader) -> ExternResult<bool> {
-    Ok(handle_delete_resource_specification(address)?)
+fn delete_resource_specification(ByRevision { revision_id }: ByRevision) -> ExternResult<bool> {
+    Ok(handle_delete_resource_specification(revision_id)?)
 }

--- a/zomes/rea_satisfaction/rpc/src/lib.rs
+++ b/zomes/rea_satisfaction/rpc/src/lib.rs
@@ -11,7 +11,7 @@ use holochain_serialized_bytes::prelude::*;
 use serde_maybe_undefined::{MaybeUndefined};
 use vf_measurement::QuantityValue;
 pub use vf_attributes_hdk::{
-    HeaderHash, ByHeader, ByAddress,
+    HeaderHash, ByHeader, ByAddress, ByRevision,
     SatisfactionAddress,
     EventOrCommitmentAddress,
     EconomicEventAddress,

--- a/zomes/rea_satisfaction/rpc/src/lib.rs
+++ b/zomes/rea_satisfaction/rpc/src/lib.rs
@@ -22,11 +22,13 @@ pub use vf_attributes_hdk::{
 /// Toplevel I/O structs for WASM API
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateParams {
     pub satisfaction: CreateRequest,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UpdateParams {
     pub satisfaction: UpdateRequest,
 }

--- a/zomes/rea_satisfaction/zome_observation/src/lib.rs
+++ b/zomes/rea_satisfaction/zome_observation/src/lib.rs
@@ -61,6 +61,6 @@ fn satisfaction_updated(UpdateParams { satisfaction }: UpdateParams) -> ExternRe
 }
 
 #[hdk_extern]
-fn satisfaction_deleted(ByHeader { address }: ByHeader) -> ExternResult<bool> {
-    Ok(handle_delete_satisfaction(address)?)
+fn satisfaction_deleted(ByRevision { revision_id }: ByRevision) -> ExternResult<bool> {
+    Ok(handle_delete_satisfaction(revision_id)?)
 }

--- a/zomes/rea_satisfaction/zome_planning/src/lib.rs
+++ b/zomes/rea_satisfaction/zome_planning/src/lib.rs
@@ -59,6 +59,6 @@ fn update_satisfaction(UpdateParams { satisfaction }: UpdateParams) -> ExternRes
 }
 
 #[hdk_extern]
-fn delete_satisfaction(ByHeader { address }: ByHeader) -> ExternResult<bool> {
-    Ok(handle_delete_satisfaction(address)?)
+fn delete_satisfaction(ByRevision { revision_id }: ByRevision) -> ExternResult<bool> {
+    Ok(handle_delete_satisfaction(revision_id)?)
 }

--- a/zomes/rea_unit/rpc/src/lib.rs
+++ b/zomes/rea_unit/rpc/src/lib.rs
@@ -19,6 +19,7 @@ use hdk_records::{
 pub use vf_attributes_hdk::{
     HeaderHash,
     UnitId,
+    ByRevision,
 };
 
 /// I/O struct to describe the complete record, including all managed link fields

--- a/zomes/rea_unit/zome/src/lib.rs
+++ b/zomes/rea_unit/zome/src/lib.rs
@@ -29,6 +29,7 @@ fn entry_defs(_: ()) -> ExternResult<EntryDefsCallbackResult> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct CreateParams {
     pub unit: CreateRequest,
 }
@@ -49,6 +50,7 @@ fn get_unit(ById { id }: ById) -> ExternResult<ResponseData> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct UpdateParams {
     pub unit: UpdateRequest,
 }

--- a/zomes/rea_unit/zome/src/lib.rs
+++ b/zomes/rea_unit/zome/src/lib.rs
@@ -59,6 +59,6 @@ fn update_unit(UpdateParams { unit }: UpdateParams) -> ExternResult<ResponseData
 }
 
 #[hdk_extern]
-fn delete_unit(ByHeader { address }: ByHeader) -> ExternResult<bool> {
-    Ok(handle_delete_unit(address)?)
+fn delete_unit(ByRevision { revision_id }: ByRevision) -> ExternResult<bool> {
+    Ok(handle_delete_unit(revision_id)?)
 }


### PR DESCRIPTION
The main typescript error feedback we are getting now has to do with a slight different in a type definition and the actual object that gets passed in.

for example, from the `economicResource` resolver: 
```
const readResourceSpecification = mapZomeFn<ReadParams, ResourceSpecificationResponse>(dnaConfig, conductorUri, 'specification', 'resource_specification', 'get_resource_specification')

...

conformsTo: async (record: EconomicResource): Promise<ResourceSpecification> => {
        return (await readResourceSpecification({ address: record.conformsTo})).resourceSpecification
      },
```

because we declare record as `EconomicResource` then ts thinks that record.conformsTo is of type `ResourceSpecification` but really at this layer it is an id, which we use to return a ResourceSpecification. Which makes me wonder how to properly type the `record` input, as it isn't quite the `EconomicResource` object, but the base object which contains the ids of all the linked objects.