### PR TITLE
add TRYORAMA_LOG_LEVEL=debug to test:integration so that we can if we want access the wasm debug statements

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "playground": "holochain-playground",
-    "test": "WASM_LOG=debug RUST_LOG=\"debug,wasmer_compiler_cranelift=error,holochain::core::workflow=error,holochain::conductor::entry_def_store=error\" RUST_BACKTRACE=1 GRAPHQL_DEBUG=1 tape **/*.js | tap-dot"
+    "test": "TRYORAMA_LOG_LEVEL=debug WASM_LOG=debug RUST_LOG=\"debug,wasmer_compiler_cranelift=error,holochain::core::workflow=error,holochain::conductor::entry_def_store=error\" RUST_BACKTRACE=1 GRAPHQL_DEBUG=1 tape **/*.js | tap-dot"
   },
   "devDependencies": {
     "@babel/core": "^7.18.5",


### PR DESCRIPTION
closes #305 especially when combined with the documentation I already added into docs/README.md

when piped through `tap-dot` this doesn't technically show up, but it's still useful in case we want to fiddle temporarily with the command, or else copy-paste it somewhere