### PR TITLE
More flexible index macros to allow String-based identifiers for agent_type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +39,12 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bit-set"
@@ -48,6 +66,17 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "byteorder"
@@ -89,6 +118,12 @@ dependencies = [
  "unicode-width",
  "vec_map",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "convert_case"
@@ -1526,6 +1561,9 @@ version = "0.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a26d28040245acbfc9b4960926cb7c07a2788f8713e6ef1b28e01bd5d1e2734"
 dependencies = [
+ "base64",
+ "blake2b_simd",
+ "derive_more",
  "holochain_serialized_bytes",
  "kitsune_p2p_dht_arc",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,12 +273,15 @@ dependencies = [
  "hdk_records",
  "hdk_semantic_indexes_client_lib",
  "paste",
+ "serde",
 ]
 
 [[package]]
 name = "hc_zome_rea_agent_rpc"
 version = "0.1.0"
 dependencies = [
+ "hdk",
+ "hdk_uuid_types",
  "holochain_serialized_bytes",
  "serde",
  "serde_maybe_undefined",

--- a/lib/hdk_semantic_indexes/rpc/src/lib.rs
+++ b/lib/hdk_semantic_indexes/rpc/src/lib.rs
@@ -84,6 +84,7 @@ impl<A, B> RemoteEntryLinkRequest<A, B>
     }
 }
 
+/// Common response format for zomes handling indexes to report status to calling integrity zomes
 #[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
 pub struct RemoteEntryLinkResponse {
     pub indexes_created: Vec<OtherCellResult<HeaderHash>>,

--- a/lib/hdk_semantic_indexes/zome/src/lib.rs
+++ b/lib/hdk_semantic_indexes/zome/src/lib.rs
@@ -8,7 +8,6 @@
 use chrono::{DateTime, Utc};
 use hdk::prelude::*;
 use hdk_records::{
-    DnaAddressable,
     identities::{
         calculate_identity_address,
         read_entry_identity,
@@ -23,7 +22,10 @@ pub use hdk_time_indexing::{
     // get_latest_entry_hashes,
     // get_older_entry_hashes,
 };
-pub use hdk_records::{RecordAPIResult, DataIntegrityError};
+pub use hdk_records::{
+    RecordAPIResult, DataIntegrityError,
+    DnaAddressable,
+};
 pub use hdk_semantic_indexes_zome_rpc::*;
 pub use hdk_relay_pagination::PageInfo;
 

--- a/lib/hdk_semantic_indexes/zome_derive/src/lib.rs
+++ b/lib/hdk_semantic_indexes/zome_derive/src/lib.rs
@@ -284,15 +284,14 @@ pub fn index_zome(attribs: TokenStream, input: TokenStream) -> TokenStream {
             let edge_cursors = valid_edges
                 .clone()
                 .map(|node| {
-                    node.#record_type_str_ident.into_cursor()
+                    node.#record_type_str_ident.id.to_string()
                 });
 
             let formatted_edges = valid_edges.zip(edge_cursors)
-                .map(|(node, record_cursor)| {
+                .map(|(node, cursor)| {
                     Edge {
                         node: node.#record_type_str_ident,
-                        // :TODO: use HoloHashb64 once API stabilises
-                        cursor: record_cursor.unwrap_or("".to_string())
+                        cursor,
                     }
                 });
 

--- a/lib/hdk_semantic_indexes/zome_derive/src/lib.rs
+++ b/lib/hdk_semantic_indexes/zome_derive/src/lib.rs
@@ -211,6 +211,7 @@ pub fn index_zome(attribs: TokenStream, input: TokenStream) -> TokenStream {
         // @see https://relay.dev/graphql/connections.htm
         // :TODO: extend to allow for filtering with `QueryParams`
         #[derive(Debug, Serialize, Deserialize)]
+        #[serde(rename_all = "camelCase")]
         struct PagingParams {
             // :TODO: forwards pagination
             // first: Option<usize>,
@@ -221,6 +222,7 @@ pub fn index_zome(attribs: TokenStream, input: TokenStream) -> TokenStream {
 
         // query results structure mimicing Relay's pagination format
         #[derive(Debug, Serialize, Deserialize)]
+        #[serde(rename_all = "camelCase")]
         struct QueryResults {
             pub page_info: PageInfo,
             #[serde(default)]
@@ -231,6 +233,7 @@ pub fn index_zome(attribs: TokenStream, input: TokenStream) -> TokenStream {
         }
 
         #[derive(Debug, Serialize, Deserialize)]
+        #[serde(rename_all = "camelCase")]
         struct Edge {
             node: Response,
             cursor: String,

--- a/lib/hdk_uuid_types/Cargo.toml
+++ b/lib/hdk_uuid_types/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2018"
 [dependencies]
 serde = "1"
 hdk = "0.0"
-holo_hash = "0.0"
+
+# This enables .to_string() for HoloHash types using base64 encoding
+holo_hash = { version = "*",  features = ["encoding"] }
 
 [lib]
 crate-type = ["lib"]

--- a/lib/hdk_uuid_types/src/lib.rs
+++ b/lib/hdk_uuid_types/src/lib.rs
@@ -115,7 +115,7 @@ macro_rules! addressable_identifier {
         // convert to raw bytes in serializing
         impl Into<Vec<u8>> for $r {
             fn into(self) -> Vec<u8> {
-                extern_id_to_bytes::<Self, $base>(&self)
+                $crate::extern_id_to_bytes::<Self, $base>(&self)
             }
         }
     }

--- a/lib/vf_attributes_hdk/src/lib.rs
+++ b/lib/vf_attributes_hdk/src/lib.rs
@@ -4,7 +4,7 @@ use hdk_uuid_types::*;
 pub use chrono::{ FixedOffset, Utc, DateTime };
 pub use holo_hash::{ AgentPubKey, EntryHash, HeaderHash };
 pub use holochain_zome_types::timestamp::Timestamp;
-pub use hdk_uuid_types::{DnaAddressable};
+pub use hdk_uuid_types::{DnaAddressable, DnaIdentifiable};
 pub use hdk_semantic_indexes_zome_rpc::{ByHeader, ByAddress, ByRevision};
 
 simple_alias!(ActionId => String);

--- a/modules/vf-graphql-holochain/queries/process.ts
+++ b/modules/vf-graphql-holochain/queries/process.ts
@@ -15,7 +15,7 @@ import { PagingParams } from '../resolvers/zomeSearchInputTypes.js'
 
 export default (dnaConfig: DNAIdMappings, conductorUri: string) => {
   const readOne = mapZomeFn<ReadParams, ProcessResponse>(dnaConfig, conductorUri, 'observation', 'process', 'get_process')
-  const readAll = mapZomeFn<PagingParams, ProcessConnection>(dnaConfig, conductorUri, 'observation', 'process_index', 'read_all_processs')
+  const readAll = mapZomeFn<PagingParams, ProcessConnection>(dnaConfig, conductorUri, 'observation', 'process_index', 'read_all_processes')
 
   return {
     process: async (root, args): Promise<Process> => {

--- a/test/agreement/test_agreement_crud.js
+++ b/test/agreement/test_agreement_crud.js
@@ -67,7 +67,7 @@ test('Agreement record API', async (t) => {
       },
     )
     t.deepLooseEqual(
-      getResp.data.res, { id: aId, revisionId: r1Id, ...exampleEntry },
+      { ...getResp.data.res }, { id: aId, revisionId: r1Id, ...exampleEntry },
       'record read OK',
     )
 

--- a/test/agreement/test_agreement_crud.js
+++ b/test/agreement/test_agreement_crud.js
@@ -41,7 +41,7 @@ test('Agreement record API', async (t) => {
     `,
       {
         rs: exampleEntry,
-        rs2: exampleEntry,
+        rs2: exampleEntry2,
       },
     )
     await pause(100)

--- a/test/economic-event/event_resource_list_api.js
+++ b/test/economic-event/event_resource_list_api.js
@@ -151,7 +151,7 @@ test('Event/Resource list APIs', async (t) => {
       'event cursors OK',
     )
     t.equal(resp.data.economicEvents.pageInfo.startCursor, event5Id, 'event start offset cursor OK')
-    t.equal(resp.data.economicEvents.pageInfo.endCursor, event5Id, 'event end offset cursor OK')
+    t.equal(resp.data.economicEvents.pageInfo.endCursor, event1Id, 'event end offset cursor OK')
     t.equal(resp.data.economicResources.edges.length, 2, 'all resources correctly retrievable')
     t.deepLooseEqual(
       resp.data.economicResources.edges.map(e => e.node),

--- a/test/economic-event/event_resource_list_api.js
+++ b/test/economic-event/event_resource_list_api.js
@@ -114,14 +114,24 @@ test('Event/Resource list APIs', async (t) => {
 
     resp = await alice.graphQL(`{
       economicEvents(last: 10) {
+        pageInfo {
+          startCursor
+          endCursor
+        }
         edges {
+          cursor
           node {
             id
           }
         }
       }
       economicResources(last: 10) {
+        pageInfo {
+          startCursor
+          endCursor
+        }
         edges {
+          cursor
           node {
             id
           }
@@ -135,12 +145,26 @@ test('Event/Resource list APIs', async (t) => {
       [{ id: event5Id }, { id: event4Id }, { id: event3Id }, { id: event2Id }, { id: event1Id }],
       'event IDs OK',
     )
+    t.deepLooseEqual(
+      resp.data.economicEvents.edges.map(e => e.cursor),
+      [event5Id, event4Id, event3Id, event2Id, event1Id],
+      'event cursors OK',
+    )
+    t.equal(resp.data.economicEvents.pageInfo.startCursor, event5Id, 'event start offset cursor OK')
+    t.equal(resp.data.economicEvents.pageInfo.endCursor, event5Id, 'event end offset cursor OK')
     t.equal(resp.data.economicResources.edges.length, 2, 'all resources correctly retrievable')
     t.deepLooseEqual(
       resp.data.economicResources.edges.map(e => e.node),
       [{ id: resource2Id }, { id: resource1Id }],
       'resource IDs OK',
     )
+    t.deepLooseEqual(
+      resp.data.economicResources.edges.map(e => e.cursor),
+      [resource2Id, resource1Id],
+      'resource cursors OK',
+    )
+    t.equal(resp.data.economicResources.pageInfo.startCursor, resource2Id, 'resource start offset cursor OK')
+    t.equal(resp.data.economicResources.pageInfo.endCursor, resource1Id, 'resource end offset cursor OK')
   } catch (e) {
     await alice.scenario.cleanUp()
     throw e

--- a/test/specification/test_unit_crud.js
+++ b/test/specification/test_unit_crud.js
@@ -62,23 +62,22 @@ test('Unit record API', async (t) => {
     t.deepLooseEqual(getResp.data.res, { 'id': uId, revisionId: uRevision, ...exampleEntry }, 'record read OK')
 
 
-    // const queryAllUnits = await alice.graphQL(`
-    //   query {
-    //     res: units {
-    //       edges {
-    //         node {
-    //           id
-    //         }
-    //       }
-    //     }
-    //   }
-    // `,
-    // )
+    const queryAllUnits = await alice.graphQL(`
+      query {
+        res: units {
+          edges {
+            node {
+              id
+            }
+          }
+        }
+      }
+    `,
+    )
 
-    // console.log(queryAllUnits)
-    // t.equal(queryAllUnits.data.res.edges.length, 2, 'query for all units OK')
-    // t.deepEqual(queryAllUnits.data.res.edges[1].node.id, uId, 'query for all units, first unit in order OK')
-    // t.deepEqual(queryAllUnits.data.res.edges[0].node.id, u2Id, 'query for all units, second unit in order OK')
+    t.equal(queryAllUnits.data.res.edges.length, 2, 'query for all units OK')
+    t.deepEqual(queryAllUnits.data.res.edges[1].node.id, uId, 'query for all units, first unit in order OK')
+    t.deepEqual(queryAllUnits.data.res.edges[0].node.id, u2Id, 'query for all units, second unit in order OK')
     const updateResp = await alice.graphQL(`
       mutation($rs: UnitUpdateParams!) {
         res: updateUnit(unit: $rs) {

--- a/zomes/rea_agent/lib/Cargo.toml
+++ b/zomes/rea_agent/lib/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 paste = "1.0"
+serde = "1"
 hdk = "0.0.136"
 
 hdk_records = { path = "../../../lib/hdk_records" }

--- a/zomes/rea_agent/lib/src/lib.rs
+++ b/zomes/rea_agent/lib/src/lib.rs
@@ -34,22 +34,11 @@ fn read_index_zome(conf: DnaConfigSlice) -> Option<String> {
 pub fn handle_create_agent<S>(entry_def_id: S, agent: CreateRequest) -> RecordAPIResult<ResponseData>
     where S: AsRef<str> + std::fmt::Display
 {
-    let agent_type_anchor = ensure_agent_type_index_pointer(&agent.agent_type)?;
+    let agent_type = agent.agent_type.clone();
     let (header_addr, base_address, entry_resp): (_,_, EntryData) = create_record(read_index_zome, &entry_def_id, agent)?;
-    let e = create_index!(agent(&base_address).agent_type(agent_type_anchor));
+    let e = update_string_index!(agent(&base_address).agent_type(vec![agent_type])<AgentTypeId>);
     hdk::prelude::debug!("handle_create_agent::agent_type index {:?}", e);
     construct_response(&base_address, header_addr, &entry_resp, get_link_fields(&base_address)?)
-}
-
-// ensures that an EntryHash exists for linking agent type indexes to
-// :TODO: this can be done entirely in-memory after HDI upgrade, does not have to be written to the DHT
-fn ensure_agent_type_index_pointer<I>(agent_type: &I) -> RecordAPIResult<AgentTypeId>
-    where I: AsRef<str>,
-{
-    let type_path: Path = agent_type.as_ref().try_into()?;
-    type_path.ensure()?;
-
-    Ok(AgentTypeId::new(dna_info()?.hash, type_path.path_entry_hash()?))
 }
 
 /*

--- a/zomes/rea_agent/rpc/Cargo.toml
+++ b/zomes/rea_agent/rpc/Cargo.toml
@@ -7,8 +7,10 @@ edition = "2018"
 [dependencies]
 serde = "1"
 holochain_serialized_bytes = "0.0.51"
+hdk = "0.0"
 
 serde_maybe_undefined = { path = "../../../lib/serde_maybe_undefined" }
+hdk_uuid_types = { path = "../../../lib/hdk_uuid_types" }
 vf_attributes_hdk = { path = "../../../lib/vf_attributes_hdk" }
 
 [lib]

--- a/zomes/rea_agent/rpc/src/lib.rs
+++ b/zomes/rea_agent/rpc/src/lib.rs
@@ -64,13 +64,6 @@ pub struct Response {
     pub inventoried_economic_resources: Vec<EconomicResourceAddress>,
 }
 
-impl<'a> Response {
-    pub fn into_cursor(&'a self) -> Result<String, std::string::FromUtf8Error> {
-        let bytes: Vec<u8> = self.id.to_owned().into();
-        String::from_utf8(bytes)
-    }
-}
-
 /// I/O struct to describe what is returned outside the gateway.
 /// Responses are usually returned as named attributes in order to leave space
 /// for future additional return values.

--- a/zomes/rea_agent/rpc/src/lib.rs
+++ b/zomes/rea_agent/rpc/src/lib.rs
@@ -6,9 +6,9 @@
  *
  * @package Holo-REA
  */
-use holochain_serialized_bytes::prelude::*;
-
 use serde_maybe_undefined::MaybeUndefined;
+use hdk_uuid_types::{ DnaHash, addressable_identifier };
+pub use hdk::prelude::*;
 pub use vf_attributes_hdk::{
     AgentAddress,
     ProcessAddress,
@@ -21,8 +21,10 @@ pub use vf_attributes_hdk::{
     PlanAddress,
     ProposalAddress,
     ByRevision,
-
 };
+
+// internal type for indexing against agent_type string
+addressable_identifier!(AgentTypeId => EntryHash);
 
 //---------------- EXTERNAL RECORD STRUCTURE ----------------
 
@@ -156,5 +158,8 @@ pub struct QueryParams {
     pub economic_events_as_provider: Option<EconomicEventAddress>,
     pub economic_events_as_receiver: Option<EconomicEventAddress>,
     pub inventoried_economic_resources: Option<EconomicResourceAddress>,
-    pub agent_type: Option<String>, // for internal use in order to query for people or organizations specifically
+
+    // for internal use in order to query for people or organizations specifically
+    pub agent_type: Option<String>,
+    pub agent_type_internal: Option<AgentTypeId>,
 }

--- a/zomes/rea_agent/zome_idx_agent/src/lib.rs
+++ b/zomes/rea_agent/zome_idx_agent/src/lib.rs
@@ -38,6 +38,10 @@ struct Agent {
     economic_events_as_provider: Remote<economic_event, provider>,
     economic_events_as_receiver: Remote<economic_event, receiver>,
     inventoried_economic_resources: Remote<economic_resource, primary_accountable>,
-    agent_type: Local<agent, agent_type_internal>,
+
+    // query agents by type
+    agent_type: Local<agent, agent_type_internal>::String,
+    // :SHONK: redundant loopback index, required for internals of bidirectional index link management.
+    // Aside from better support for such edge-cases, the other benefit to obviating this workaround is DHT bloat.
     agent_type_internal: Local<agent, agent_type>,
 }

--- a/zomes/rea_agreement/rpc/src/lib.rs
+++ b/zomes/rea_agreement/rpc/src/lib.rs
@@ -46,13 +46,6 @@ pub struct Response {
     // pub involved_agents: Vec<AgentAddress>,
 }
 
-impl<'a> Response {
-    pub fn into_cursor(&'a self) -> Result<String, std::string::FromUtf8Error> {
-        let bytes: Vec<u8> = self.id.to_owned().into();
-        String::from_utf8(bytes)
-    }
-}
-
 /// I/O struct to describe what is returned outside the gateway.
 /// Responses are usually returned as named attributes in order to leave space
 /// for future additional return values.

--- a/zomes/rea_commitment/rpc/src/lib.rs
+++ b/zomes/rea_commitment/rpc/src/lib.rs
@@ -92,13 +92,6 @@ pub struct Response {
     pub involved_agents: Vec<AgentAddress>,
 }
 
-impl<'a> Response {
-    pub fn into_cursor(&'a self) -> Result<String, std::string::FromUtf8Error> {
-        let bytes: Vec<u8> = self.id.to_owned().into();
-        String::from_utf8(bytes)
-    }
-}
-
 /// I/O struct to describe what is returned outside the gateway.
 /// Responses are usually returned as named attributes in order to leave space
 /// for future additional return values.

--- a/zomes/rea_economic_event/lib/src/lib.rs
+++ b/zomes/rea_economic_event/lib/src/lib.rs
@@ -29,7 +29,6 @@ use hc_zome_rea_economic_event_storage::*;
 use hc_zome_rea_economic_event_rpc::{
     CreateRequest as EconomicEventCreateRequest,
     UpdateRequest as EconomicEventUpdateRequest,
-    EventResponseEdge as Edge,
 };
 use hc_zome_rea_economic_resource_rpc::{ CreationPayload as ResourceCreationPayload };
 
@@ -359,23 +358,6 @@ pub fn construct_response<'a>(
             satisfies: satisfactions.to_owned(),
         },
         economic_resource: None,
-    })
-}
-
-pub fn construct_list_response<'a>(
-    address: &EconomicEventAddress, revision_id: &HeaderHash, e: &EntryData, (
-        fulfillments,
-        satisfactions,
-    ): (
-        Vec<FulfillmentAddress>,
-        Vec<SatisfactionAddress>,
-    )
-) -> RecordAPIResult<Edge> {
-    let record_cursor: Vec<u8> = address.to_owned().into();
-    Ok(Edge {
-        node: construct_response(address, revision_id, e, (fulfillments, satisfactions))?.economic_event,
-        // :TODO: use HoloHashb64 once API stabilises
-        cursor: String::from_utf8(record_cursor).unwrap_or("".to_string())
     })
 }
 

--- a/zomes/rea_economic_event/rpc/src/lib.rs
+++ b/zomes/rea_economic_event/rpc/src/lib.rs
@@ -87,13 +87,6 @@ pub struct Response {
     pub satisfies: Vec<SatisfactionAddress>,
 }
 
-impl<'a> Response {
-    pub fn into_cursor(&'a self) -> Result<String, std::string::FromUtf8Error> {
-        let bytes: Vec<u8> = self.id.to_owned().into();
-        String::from_utf8(bytes)
-    }
-}
-
 /// I/O struct to describe EconomicResources, including all managed link fields
 /// Defined here since EconomicEvent responses may contain EconomicResource data
 ///
@@ -141,13 +134,6 @@ pub struct ResourceResponse {
     // trace: Option<Vec<EconomicEventAddress>>,
     // #[serde(skip_serializing_if = "Option::is_none")]
     // track: Option<Vec<EconomicEventAddress>>,
-}
-
-impl<'a> ResourceResponse {
-    pub fn into_cursor(&'a self) -> Result<String, std::string::FromUtf8Error> {
-        let bytes: Vec<u8> = self.id.to_owned().into();
-        String::from_utf8(bytes)
-    }
 }
 
 /// I/O struct to describe what is returned outside the gateway

--- a/zomes/rea_economic_resource/lib/src/lib.rs
+++ b/zomes/rea_economic_resource/lib/src/lib.rs
@@ -42,7 +42,6 @@ use hc_zome_rea_economic_event_storage::{EntryData as EventData, EntryStorage as
 use hc_zome_rea_economic_event_rpc::{
     ResourceResponse as Response,
     ResourceResponseData as ResponseData,
-    ResourceResponseEdge as Edge,
     ResourceInventoryType,
     CreateRequest as EventCreateRequest,
 };
@@ -246,27 +245,6 @@ pub fn construct_response_record<'a>(
         // link fields
         contained_in: contained_in.to_owned(),
         contains: contains.to_owned(),
-    })
-}
-
-pub fn construct_list_response<'a>(
-    address: &EconomicResourceAddress, revision_id: &HeaderHash, e: &EntryData, (
-        contained_in,
-        stage,
-        state,
-        contains,
-    ): (
-        Option<EconomicResourceAddress>,
-        Option<ProcessSpecificationAddress>,
-        Option<ActionId>,
-        Vec<EconomicResourceAddress>,
-    )
-) -> RecordAPIResult<Edge> {
-    let record_cursor: Vec<u8> = address.to_owned().into();
-    Ok(Edge {
-        node: construct_response(address, revision_id, e, (contained_in, stage, state, contains))?.economic_resource,
-        // :TODO: use HoloHashb64 once API stabilises
-        cursor: String::from_utf8(record_cursor).unwrap_or("".to_string())
     })
 }
 

--- a/zomes/rea_fulfillment/rpc/src/lib.rs
+++ b/zomes/rea_fulfillment/rpc/src/lib.rs
@@ -52,13 +52,6 @@ pub struct Response {
     pub note: Option<String>,
 }
 
-impl<'a> Response {
-    pub fn into_cursor(&'a self) -> Result<String, std::string::FromUtf8Error> {
-        let bytes: Vec<u8> = self.id.to_owned().into();
-        String::from_utf8(bytes)
-    }
-}
-
 /// I/O struct to describe what is returned outside the gateway.
 /// Responses are usually returned as named attributes in order to leave space
 /// for future additional return values.

--- a/zomes/rea_intent/rpc/src/lib.rs
+++ b/zomes/rea_intent/rpc/src/lib.rs
@@ -83,13 +83,6 @@ pub struct Response {
     // pub published_in: Option<Vec<ProposedIntentAddress>>,
 }
 
-impl<'a> Response {
-    pub fn into_cursor(&'a self) -> Result<String, std::string::FromUtf8Error> {
-        let bytes: Vec<u8> = self.id.to_owned().into();
-        String::from_utf8(bytes)
-    }
-}
-
 /// I/O struct to describe what is returned outside the gateway.
 /// Responses are usually returned as named attributes in order to leave space
 /// for future additional return values.

--- a/zomes/rea_plan/rpc/src/lib.rs
+++ b/zomes/rea_plan/rpc/src/lib.rs
@@ -46,13 +46,6 @@ pub struct Response {
     pub independent_demands: Vec<CommitmentAddress>,
 }
 
-impl<'a> Response {
-    pub fn into_cursor(&'a self) -> Result<String, std::string::FromUtf8Error> {
-        let bytes: Vec<u8> = self.id.to_owned().into();
-        String::from_utf8(bytes)
-    }
-}
-
 /// I/O struct to describe what is returned outside the gateway.
 /// Responses are usually returned as named attributes in order to leave space
 /// for future additional return values.

--- a/zomes/rea_process/rpc/src/lib.rs
+++ b/zomes/rea_process/rpc/src/lib.rs
@@ -89,13 +89,6 @@ pub struct Response {
     pub track: Vec<EconomicEventAddress>,
 }
 
-impl<'a> Response {
-    pub fn into_cursor(&'a self) -> Result<String, std::string::FromUtf8Error> {
-        let bytes: Vec<u8> = self.id.to_owned().into();
-        String::from_utf8(bytes)
-    }
-}
-
 /// I/O struct to describe what is returned outside the gateway
 #[derive(Clone, Serialize, Deserialize, SerializedBytes, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/zomes/rea_process/zome_idx_observation/src/lib.rs
+++ b/zomes/rea_process/zome_idx_observation/src/lib.rs
@@ -22,7 +22,7 @@ fn entry_defs(_: ()) -> ExternResult<EntryDefsCallbackResult> {
     ]))
 }
 
-#[index_zome(query_fn_name="query_processes")]
+#[index_zome(query_fn_name="query_processes",read_all_fn_name="read_all_processes")]
 struct Process {
     observed_inputs: Local<economic_event, input_of>,
     observed_outputs: Local<economic_event, output_of>,

--- a/zomes/rea_process_specification/rpc/src/lib.rs
+++ b/zomes/rea_process_specification/rpc/src/lib.rs
@@ -40,13 +40,6 @@ pub struct Response {
     pub note: Option<String>,
 }
 
-impl<'a> Response {
-    pub fn into_cursor(&'a self) -> Result<String, std::string::FromUtf8Error> {
-        let bytes: Vec<u8> = self.id.to_owned().into();
-        String::from_utf8(bytes)
-    }
-}
-
 /// I/O struct to describe what is returned outside the gateway
 #[derive(Serialize, Deserialize, Debug, SerializedBytes, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/zomes/rea_proposal/rpc/src/lib.rs
+++ b/zomes/rea_proposal/rpc/src/lib.rs
@@ -59,13 +59,6 @@ pub struct Response {
     pub published_to: Vec<ProposedToAddress>,
 }
 
-impl<'a> Response {
-    pub fn into_cursor(&'a self) -> Result<String, std::string::FromUtf8Error> {
-        let bytes: Vec<u8> = self.id.to_owned().into();
-        String::from_utf8(bytes)
-    }
-}
-
 /// I/O struct to describe what is returned outside the gateway.
 /// Responses are usually returned as named attributes in order to leave space
 /// for future additional return values.

--- a/zomes/rea_proposed_intent/rpc/src/lib.rs
+++ b/zomes/rea_proposed_intent/rpc/src/lib.rs
@@ -25,13 +25,6 @@ pub struct Response {
     pub publishes: IntentAddress,
 }
 
-impl<'a> Response {
-    pub fn into_cursor(&'a self) -> Result<String, std::string::FromUtf8Error> {
-        let bytes: Vec<u8> = self.id.to_owned().into();
-        String::from_utf8(bytes)
-    }
-}
-
 /// I/O struct to describe what is returned outside the gateway.
 /// Responses are usually returned as named attributes in order to leave space
 /// for future additional return values.

--- a/zomes/rea_proposed_to/rpc/src/lib.rs
+++ b/zomes/rea_proposed_to/rpc/src/lib.rs
@@ -33,13 +33,6 @@ pub struct Response {
     pub proposed: ProposalAddress,
 }
 
-impl<'a> Response {
-    pub fn into_cursor(&'a self) -> Result<String, std::string::FromUtf8Error> {
-        let bytes: Vec<u8> = self.id.to_owned().into();
-        String::from_utf8(bytes)
-    }
-}
-
 /// I/O struct to describe what is returned outside the gateway.
 /// Responses are usually returned as named attributes in order to leave space
 /// for future additional return values.

--- a/zomes/rea_resource_specification/rpc/src/lib.rs
+++ b/zomes/rea_resource_specification/rpc/src/lib.rs
@@ -49,13 +49,6 @@ pub struct Response {
     pub default_unit_of_effort: Option<UnitId>,
 }
 
-impl<'a> Response {
-    pub fn into_cursor(&'a self) -> Result<String, std::string::FromUtf8Error> {
-        let bytes: Vec<u8> = self.id.to_owned().into();
-        String::from_utf8(bytes)
-    }
-}
-
 /// I/O struct to describe what is returned outside the gateway.
 /// Responses are usually returned as named attributes in order to leave space
 /// for future additional return values.

--- a/zomes/rea_satisfaction/rpc/src/lib.rs
+++ b/zomes/rea_satisfaction/rpc/src/lib.rs
@@ -52,13 +52,6 @@ pub struct Response {
     pub note: Option<String>,
 }
 
-impl<'a> Response {
-    pub fn into_cursor(&'a self) -> Result<String, std::string::FromUtf8Error> {
-        let bytes: Vec<u8> = self.id.to_owned().into();
-        String::from_utf8(bytes)
-    }
-}
-
 /// I/O struct to describe what is returned outside the gateway.
 /// Responses are usually returned as named attributes in order to leave space
 /// for future additional return values.

--- a/zomes/rea_unit/lib/src/lib.rs
+++ b/zomes/rea_unit/lib/src/lib.rs
@@ -6,6 +6,7 @@
  *
  * @package Holo-REA
  */
+use hdk::prelude::*;
 use hdk_records::{
     RecordAPIResult,
     records_anchored::{
@@ -14,10 +15,12 @@ use hdk_records::{
         update_anchored_record,
         delete_anchored_record,
     },
+    records::read_record_entry,
 };
 
 pub use vf_attributes_hdk::{
     ByHeader, ByAddress,
+    DnaIdentifiable,
 };
 
 pub use hc_zome_rea_unit_storage_consts::*;
@@ -42,6 +45,17 @@ pub fn handle_get_unit<S>(entry_def_id: S, id: UnitId) -> RecordAPIResult<Respon
     let id_str: &String = id.as_ref();
     let (revision_id, entry_id, entry): (_,UnitId,_) = read_anchored_record_entry::<EntryData, EntryStorage, UnitInternalAddress, _,_,_>(&entry_def_id, id_str)?;
     Ok(construct_response(&entry_id, &revision_id, &entry))
+}
+
+// internal method used by index zomes to locate indexed unit record data
+pub fn handle_get_unit_by_address<S>(entry_def_id: S, address: UnitInternalAddress) -> RecordAPIResult<ResponseData>
+    where S: AsRef<str>,
+{
+    let (revision, _base_address, entry) = read_record_entry::<EntryData, EntryStorage, _,_,_>(&entry_def_id, address.as_ref())?;
+    Ok(construct_response(&UnitId::new(
+        dna_info()?.hash,
+        entry.symbol.to_owned(),
+    ), &revision, &entry))
 }
 
 pub fn handle_update_unit<S>(entry_def_id: S, unit: UpdateRequest) -> RecordAPIResult<ResponseData>

--- a/zomes/rea_unit/zome/src/lib.rs
+++ b/zomes/rea_unit/zome/src/lib.rs
@@ -48,6 +48,12 @@ fn get_unit(ById { id }: ById) -> ExternResult<ResponseData> {
     Ok(handle_get_unit(UNIT_ENTRY_TYPE, id)?)
 }
 
+// used by indexing zomes to retrieve indexed record data
+#[hdk_extern]
+fn __internal_get_unit_by_hash(ByAddress { address }: ByAddress<UnitInternalAddress>) -> ExternResult<ResponseData> {
+    Ok(handle_get_unit_by_address(UNIT_ENTRY_TYPE, address)?)
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct UpdateParams {

--- a/zomes/rea_unit/zome_idx_specification/src/lib.rs
+++ b/zomes/rea_unit/zome_idx_specification/src/lib.rs
@@ -18,7 +18,7 @@ fn entry_defs(_: ()) -> ExternResult<EntryDefsCallbackResult> {
     ]))
 }
 
-#[index_zome]
+#[index_zome(record_read_fn_name="__internal_get_unit_by_hash")]
 struct Unit {
     // :NOTE: blank means only the `read_all_` and `register_new_` APIs will be generated
 }


### PR DESCRIPTION
This should help with #326. All `Agent` tests seem to be passing, but I haven't checked the status of them to see which parts of the behaviour they're exercising. Merge when you feel happy with this approach.

Now closes #330 in addition to enabling `agent_type` to work.