### PR TITLE
add `Unit` read API for loading by symbol rather than fully-qualified record UUID

### DIFF
--- a/test/specification/test_unit_crud.js
+++ b/test/specification/test_unit_crud.js
@@ -29,12 +29,14 @@ test('Unit record API', async (t) => {
           unit {
             id
             revisionId
+            symbol
           }
         }
         res2: createUnit(unit: $rs2) {
           unit {
             id
             revisionId
+            symbol
           }
         }
       }
@@ -64,6 +66,7 @@ test('Unit record API', async (t) => {
     })
 
     const expectedRecord = { 'id': uId, revisionId: uRevision, ...exampleEntry }
+
     t.deepLooseEqual(getResp.data.res, expectedRecord, 'record read OK')
 
     const getSResp = await alice.graphQL(`

--- a/test/specification/test_unit_crud.js
+++ b/test/specification/test_unit_crud.js
@@ -47,6 +47,7 @@ test('Unit record API', async (t) => {
     t.ok(createResp.data.res.unit.id, 'record created')
     t.equal(createResp.data.res.unit.id.split(':')[0], exampleEntry.symbol, 'record index set')
     let uId = createResp.data.res.unit.id
+    let uSymbol = createResp.data.res.unit.symbol
     let u2Id = createResp.data.res2.unit.id
     let uRevision = createResp.data.res.unit.revisionId
     const getResp = await alice.graphQL(`
@@ -62,7 +63,22 @@ test('Unit record API', async (t) => {
       id: uId,
     })
 
-    t.deepLooseEqual(getResp.data.res, { 'id': uId, revisionId: uRevision, ...exampleEntry }, 'record read OK')
+    const expectedRecord = { 'id': uId, revisionId: uRevision, ...exampleEntry }
+    t.deepLooseEqual(getResp.data.res, expectedRecord, 'record read OK')
+
+    const getSResp = await alice.graphQL(`
+      query($id: ID!) {
+        res: unit(id: $id) {
+          id
+          revisionId
+          label
+          symbol
+        }
+      }
+      `, {
+      id: uSymbol,
+    })
+    t.deepLooseEqual(getSResp.data.res, expectedRecord, 'record read by (globally-unique, not universally-unique) symbol OK')
 
 
     const queryAllUnits = await alice.graphQL(`

--- a/zomes/rea_unit/lib/src/lib.rs
+++ b/zomes/rea_unit/lib/src/lib.rs
@@ -61,6 +61,17 @@ pub fn handle_get_unit(id: UnitId) -> RecordAPIResult<ResponseData>
     construct_response(&entry_id, &meta, &entry)
 }
 
+pub fn handle_get_unit_by_symbol<S>(symbol: S) -> RecordAPIResult<ResponseData>
+    where S: AsRef<str> + std::fmt::Display,
+{
+    let (meta, entry_id, entry): (_,UnitId,_) =
+      read_anchored_record_entry::<LinkTypes, EntryData, EntryStorage, UnitInternalAddress, _,_>(
+        LinkTypes::UnitIdentifier,
+        symbol.as_ref(),
+      )?;
+    construct_response(&entry_id, &meta, &entry)
+}
+
 // internal method used by index zomes to locate indexed unit record data
 pub fn handle_get_unit_by_address(address: UnitInternalAddress) -> RecordAPIResult<ResponseData>
 {

--- a/zomes/rea_unit/zome/src/lib.rs
+++ b/zomes/rea_unit/zome/src/lib.rs
@@ -34,6 +34,16 @@ fn get_unit(ById { id }: ById) -> ExternResult<ResponseData> {
     Ok(handle_get_unit(id)?)
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+struct BySymbol {
+    symbol: String,
+}
+
+#[hdk_extern]
+fn get_unit_by_symbol(BySymbol { symbol }: BySymbol) -> ExternResult<ResponseData> {
+    Ok(handle_get_unit_by_symbol(symbol)?)
+}
+
 // used by indexing zomes to retrieve indexed record data
 #[hdk_extern]
 fn __internal_get_unit_by_hash(ByAddress { address }: ByAddress<UnitInternalAddress>) -> ExternResult<ResponseData> {


### PR DESCRIPTION
I'm not sure how you might feel about this addition; but it seems like a necessary bit of ergonomics for hREA-based apps.

I want to be able to declare this as a data dependency in my view component(s):

```graphql
  query {
    hours: unit(id: "hours") {
      id
      label
      symbol
    }
    minutes: unit(id: "minute") {
      id
      label
      symbol
    }
    seconds: unit(id: "second") {
      id
      label
      symbol
    }
  }
```

The key parameter is the `id` in each query. The only way of interacting currently is to pass the values directly; i.e. the universally-unique combination of `(DnaHash, String)`, which necessitates query variables:

```ts
  units: ApolloQueryController<CoreUnitsCheckResponse> = new ApolloQueryController(this, HasCoreUnits, {
    variables: {
      hours: `${dnaHashB64}:hours`,
      minutes: `${dnaHashB64}:minutes`,
      seconds: `${dnaHashB64}:seconds`,
    }
  })
```

Where would `dnaHashB64` come from? This seems like an implementation detail of the Valueflows network, which client applications should not have to interact with at all. So, we should be able to refer to units by well-known strings for simplified retrieval. I think with this addition to the top-level query we can take the wrapped `UnitIds` from this request and link to other records as needed in mutations.